### PR TITLE
fix name of the nodes in the health monitor map

### DIFF
--- a/health_monitor/include/health_monitor.h
+++ b/health_monitor/include/health_monitor.h
@@ -80,12 +80,12 @@ private:
         {"payload_manager", health_monitor::ReportFault::PAYLOAD_NODE_DIED},
         {"vectornav", health_monitor::ReportFault::AHRS_NODE_DIED},
         {"pressure_sensor", health_monitor::ReportFault::PRESSURE_NODE_DIED},
-        {"mission_manager", health_monitor::ReportFault::MISSION_NODE_DIED},
-        {"pose_estimator", health_monitor::ReportFault::POSE_NODE_DIED},
-        {"thruster", health_monitor::ReportFault::THRUSTER_NODE_DIED},
-        {"autopilot", health_monitor::ReportFault::AUTOPILOT_NODE_DIED},
-        {"battery_monitor", health_monitor::ReportFault::BATTERY_NODE_DIED},
-        {"jaus_node_bridge", health_monitor::ReportFault::JAUS_NODE_DIED}};
+        {"mission_manager_node", health_monitor::ReportFault::MISSION_NODE_DIED},
+        {"pose_estimator_node", health_monitor::ReportFault::POSE_NODE_DIED},
+        {"thruster_control_node", health_monitor::ReportFault::THRUSTER_NODE_DIED},
+        {"autopilot_node", health_monitor::ReportFault::AUTOPILOT_NODE_DIED},
+        {"battery_monitor_node", health_monitor::ReportFault::BATTERY_NODE_DIED},
+        {"jaus_ros_bridge", health_monitor::ReportFault::JAUS_NODE_DIED}};
 
     void handle_ClearFault(const health_monitor::ClearFault::ConstPtr &msg);
     void handle_diagnostics(const diagnostic_msgs::DiagnosticArrayPtr &msg);


### PR DESCRIPTION
The names of the nodes to create the fault map in health monitor were taken from the node source files and not from the launch files.
Now, the names of the nodes are the same as those of the launch files.