### PR TITLE
Rework fin_control diagnostics

### DIFF
--- a/diagnostics_tools/include/diagnostic_tools/health_check.h
+++ b/diagnostics_tools/include/diagnostic_tools/health_check.h
@@ -9,6 +9,8 @@
 #include <mutex>
 #include <string>
 
+#include <boost/make_unique.hpp>
+
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 

--- a/fin_control/include/fin_control.h
+++ b/fin_control/include/fin_control.h
@@ -83,8 +83,6 @@
 
 #include <diagnostic_updater/diagnostic_updater.h>
 
-#include <diagnostic_tools/diagnosed_publisher.h>
-
 #include <diagnostic_tools/health_check.h>
 
 #include <health_monitor/ReportFault.h>
@@ -164,7 +162,7 @@ class FinControl
 
   ros::Subscriber subscriber_enableReportAngles;
 
-  diagnostic_tools::DiagnosedPublisher<fin_control::ReportAngle> publisher_reportAngle;
+  ros::Publisher publisher_reportAngle;
 
   DynamixelWorkbench myWorkBench;
 

--- a/fin_control/src/fin_control.cpp
+++ b/fin_control/src/fin_control.cpp
@@ -242,7 +242,6 @@ void FinControl::reportAngle(uint8_t id) {
     finAngleCheck.test(message.angle_in_radians);
 
     publisher_reportAngle.publish(message);
-    diagnosticsUpdater.update();
     // ROS_INFO("reportAngle published. Angle is: %d", message.angle_in_radians);
   } else
     ROS_ERROR("Could not get servo angle for ID %d %s", message.ID, log);
@@ -385,6 +384,7 @@ void FinControl::handle_EnableReportAngles(const fin_control::EnableReportAngles
 void FinControl::workerFunc() {
   while (fincontrolEnabled) {
     reportAngles();
+    diagnosticsUpdater.update();
     // sleep to maintain 25Hz update period
     // if changing this number update durations above.
     usleep(static_cast<int>(reportAngleRate * 1e6));


### PR DESCRIPTION
This pull request drops rate checks for `fin_control` angle reporting topic, as it is disabled during missions. 

Additionally, it ensures diagnostic updates occur even if angle reporting is disabled.