### PR TITLE
Refactor health monitor

### DIFF
--- a/health_monitor/CMakeLists.txt
+++ b/health_monitor/CMakeLists.txt
@@ -7,8 +7,9 @@ add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  rospy
+  roslint
   rosmon_msgs
+  rospy
   std_msgs
   sensor_msgs
   message_generation
@@ -49,6 +50,15 @@ add_executable(${NODE_APP_NAME}
 )
 
 add_dependencies(${NODE_APP_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+roslint_cpp(
+  src/health_monitor.cpp
+  src/health_monitor_main.cpp
+  include/health_monitor/health_monitor.h
+)
+
+roslint_add_test()
+
 
 target_include_directories(${NODE_APP_NAME} PUBLIC)
 

--- a/health_monitor/CMakeLists.txt
+++ b/health_monitor/CMakeLists.txt
@@ -3,12 +3,8 @@ project(health_monitor)
 
 set(NODE_APP_NAME ${PROJECT_NAME}_node)
 
-## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
@@ -20,58 +16,11 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_updater
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
 add_message_files(
    FILES
    ReportFault.msg
    ClearFault.msg
  )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
 
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
@@ -80,89 +29,29 @@ generate_messages(
    rosmon_msgs
  )
 
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
-#  LIBRARIES health_monitor
   CATKIN_DEPENDS roscpp rospy std_msgs rosmon_msgs
-#  DEPENDS system_lib
 )
 
 ###########
 ## Build ##
 ###########
 
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
 )
 
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/health_monitor.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/health_monitor_node.cpp)
 add_executable(${NODE_APP_NAME} 
-	src/health_monitor_main.cpp
-	src/health_monitor.cpp
+  src/health_monitor_main.cpp
+  src/health_monitor.cpp
 )
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_dependencies(${NODE_APP_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-#message (STATUS, "${ENV}")
-
 target_include_directories(${NODE_APP_NAME} PUBLIC)
 
-## Specify libraries to link a library or executable target against
  target_link_libraries(${NODE_APP_NAME}
    ${catkin_LIBRARIES}
     rt
@@ -175,45 +64,13 @@ target_include_directories(${NODE_APP_NAME} PUBLIC)
 ## Install ##
 #############
 
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
 install(TARGETS ${NODE_APP_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
 install(FILES
   launch/health_monitor.launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_health_monitor.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/health_monitor/include/health_monitor/health_monitor.h
+++ b/health_monitor/include/health_monitor/health_monitor.h
@@ -39,8 +39,8 @@
  * health_monitor.h
  */
 
-#ifndef _HEALTH_MONITOR_H_
-#define _HEALTH_MONITOR_H_
+#ifndef HEALTH_MONITOR_HEALTH_MONITOR_H
+#define HEALTH_MONITOR_HEALTH_MONITOR_H
 
 #include <ros/ros.h>
 
@@ -54,7 +54,8 @@
 #include <diagnostic_tools/diagnosed_publisher.h>
 #include <diagnostic_tools/health_check.h>
 #include <diagnostic_updater/diagnostic_updater.h>
-
+#include <diagnostic_tools/message_stagnation_check.h>
+#include <diagnostic_tools/periodic_message_status.h>
 
 namespace qna
 {
@@ -64,7 +65,7 @@ namespace robot
 class HealthMonitor
 {
 public:
-    HealthMonitor(ros::NodeHandle &nodeHandle);
+    explicit HealthMonitor(ros::NodeHandle &nodeHandle);
     virtual ~HealthMonitor();
 
     ros::Timer reportFaultsTimer;
@@ -76,7 +77,8 @@ public:
 private:
     std::mutex faultArrayMutex;
     uint64_t faults;
-    std::unordered_map<std::string, uint64_t> uErrorMap{
+    std::unordered_map<std::string, uint64_t> uErrorMap
+        {
         {"payload_manager", health_monitor::ReportFault::PAYLOAD_NODE_DIED},
         {"vectornav", health_monitor::ReportFault::AHRS_NODE_DIED},
         {"pressure_sensor", health_monitor::ReportFault::PRESSURE_NODE_DIED},
@@ -85,7 +87,8 @@ private:
         {"thruster_control_node", health_monitor::ReportFault::THRUSTER_NODE_DIED},
         {"autopilot_node", health_monitor::ReportFault::AUTOPILOT_NODE_DIED},
         {"battery_monitor_node", health_monitor::ReportFault::BATTERY_NODE_DIED},
-        {"jaus_ros_bridge", health_monitor::ReportFault::JAUS_NODE_DIED}};
+        {"jaus_ros_bridge", health_monitor::ReportFault::JAUS_NODE_DIED}
+        };
 
     void handle_ClearFault(const health_monitor::ClearFault::ConstPtr &msg);
     void handle_diagnostics(const diagnostic_msgs::DiagnosticArrayPtr &msg);
@@ -100,7 +103,7 @@ private:
     diagnostic_updater::Updater diagnosticsUpdater;
 };
 
-}
-}
+}   // namespace robot
+}   // namespace qna
 
-#endif // _HEALTH_MONITOR_H_
+#endif  // HEALTH_MONITOR_HEALTH_MONITOR_H

--- a/health_monitor/msg/ClearFault.msg
+++ b/health_monitor/msg/ClearFault.msg
@@ -1,5 +1,5 @@
 
-uint32 ALL_FAULTS = 0
+uint64 ALL_FAULTS = 0
 
 std_msgs/Header header
-uint32 fault_id
+uint64 fault_id

--- a/health_monitor/package.xml
+++ b/health_monitor/package.xml
@@ -4,74 +4,27 @@
   <version>1.0.0</version>
   <description>The health_monitor package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="dev@todo.todo">dev</maintainer>
+  <maintainer email="Christopher.Scianna@us.QinetiQ.com">Christopher Scianna</maintainer>
+  <license>BSD</license>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/health_monitor</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>rosmon_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>diagnostic_tools</build_depend>
   <build_depend>diagnostic_updater</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rosmon_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>rosmon_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>diagnostic_tools</exec_depend>
-  <exec_depend>rosmon</exec_depend>
   <exec_depend>diagnostic_updater</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rosmon</exec_depend>
+  <exec_depend>rosmon_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -101,26 +101,26 @@ void HealthMonitor::handle_ClearFault(const health_monitor::ClearFault::ConstPtr
 
 void HealthMonitor::handle_diagnostics(const diagnostic_msgs::DiagnosticArrayPtr &msg)
 {
-    uint64_t error_values = 0;
+    uint64_t errorValues = 0;
     for (int i = 0; i < msg->status.size(); i++)
     {
         if ((msg->status[i].level != diagnostic_msgs::DiagnosticStatus::OK) &&
             (msg->status[i].values.size() > 0) &&
             (msg->status[i].values[0].key == "Code"))
         {
-            error_values |= stoi(msg->status[i].values[0].value);
+            errorValues |= stoi(msg->status[i].values[0].value);
         }
     }
-    if (error_values != 0)
+    if (errorValues != 0)
     {
-        setFault(error_values);
+        setFault(errorValues);
         sendFaults();
     }
 }
 
 void HealthMonitor::handle_rosmonFaults(const rosmon_msgs::State &msg)
 {
-    uint64_t error_values = 0;
+    uint64_t errorValues = 0;
     for (int i = 0; i < msg.nodes.size(); i++)
     {
         if (msg.nodes[i].state == rosmon_msgs::NodeState::CRASHED)
@@ -133,13 +133,13 @@ void HealthMonitor::handle_rosmonFaults(const rosmon_msgs::State &msg)
             }
             else
             {
-                error_values |= uErrorMap[msg.nodes[i].name];
+                errorValues |= uErrorMap[msg.nodes[i].name];
             }
         }
     }
-    if (error_values != 0)
+    if (errorValues != 0)
     {
-        setFault(error_values);
+        setFault(errorValues);
         sendFaults();
     }
 }
@@ -156,12 +156,12 @@ void HealthMonitor::sendFaults()
     health_monitor::ReportFault message;
 
     faultArrayMutex.lock();
-    uint64_t temp_fault_id = faults;
+    uint64_t tempFaultIF = faults;
     faultArrayMutex.unlock();
 
     ROS_DEBUG_STREAM("Error Code: " << faults);
     message.header.stamp = ros::Time::now();
-    message.fault_id = temp_fault_id;
+    message.fault_id = tempFaultIF;
 
     publisher_reportFault.publish(message);
     diagnosticsUpdater.update();

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -39,10 +39,7 @@
  *
  */
 
-#include "health_monitor.h"
-
-#include <diagnostic_tools/message_stagnation_check.h>
-#include <diagnostic_tools/periodic_message_status.h>
+#include "health_monitor/health_monitor.h"
 
 namespace qna
 {
@@ -175,5 +172,5 @@ void HealthMonitor::reportFaultsTimeout(const ros::TimerEvent &timer)
     sendFaults();
 }
 
-} // namespace robot
-} // namespace qna
+}   // namespace robot
+}   // namespace qna

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -156,12 +156,12 @@ void HealthMonitor::sendFaults()
     health_monitor::ReportFault message;
 
     faultArrayMutex.lock();
-    uint64_t tempFaultIF = faults;
+    uint64_t tempFaultID = faults;
     faultArrayMutex.unlock();
 
     ROS_DEBUG_STREAM("Error Code: " << faults);
     message.header.stamp = ros::Time::now();
-    message.fault_id = tempFaultIF;
+    message.fault_id = tempFaultID;
 
     publisher_reportFault.publish(message);
     diagnosticsUpdater.update();

--- a/health_monitor/src/health_monitor_main.cpp
+++ b/health_monitor/src/health_monitor_main.cpp
@@ -38,19 +38,13 @@
  * health_monitor_main.cpp
  */
 
-#include <health_monitor.h>
-
+#include "health_monitor/health_monitor.h"
 #include <ros/ros.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <fstream>
-#include <iostream>
-#include <vector>
 
 // Version log
-// 1.0 		Initial versio
-// 1.0.1	Added motor temperature monitoring
-// 1.0.2	Added faults for timeouts of pressure, estimated pose, INS, and Altimeter
+// 1.0      Initial versio
+// 1.0.1    Added motor temperature monitoring
+// 1.0.2    Added faults for timeouts of pressure, estimated pose, INS, and Altimeter
 // information
 #define NODE_VERSION "1.0.2"
 


### PR DESCRIPTION
This patch:

Clean Code tasks:
- Remove unnecessary boilerplate in CMakeList.txt and Package.xml.
- Add mantainer and license.
- Add Roslint and fix linter errors.
- Change folder structure for header files. Now implemented as "include/<package_name>/header_file.h".
- Change some variable names into camelCase style

Fix bug:
- Mismatch of fault_id variable type definition in ClearFault.msg and ReportFault.msg. It was changed the size of the error bitmask in the ClearFault.msg definition to be 64bit size.

It needs thorough testing, as I don't have the hardware at hand.
