### PR TITLE
Drop unused mission_manager parameters.

### DIFF
--- a/mission_manager/launch/mission_manager.launch
+++ b/mission_manager/launch/mission_manager.launch
@@ -2,8 +2,6 @@
 	<!-- mission manager -->
 	<node pkg="mission_manager" type="mission_manager_node" name="mission_manager_node" output="screen">
 		<param name="mission_path" type="string" value="/home/dev/missions"/>
-		<param name="schema_path" type="string" value="/home/pod-devel/ros/mission_manager/missions/mission.xsd"/>
-		<param name="behavior_dir" type="string" value="/home/pod-devel/ros/mission_manager/lib"/>
 		<param name="disable_abort" type="boolean" value="true"/>
 		<param name="attitude_servo_roll_tol" type="double" value="1.0"/>
 		<param name="attitude_servo_pitch_tol" type="double" value="1.0"/>

--- a/mission_manager/src/mission_manager.cpp
+++ b/mission_manager/src/mission_manager.cpp
@@ -102,7 +102,7 @@ class MissionManagerNode
 
  private:
   // Vars holding runtime params
-  std::string mission_path, behavior_dir;
+  std::string mission_path;
   bool disable_abort;
   double reportExecuteMissionStateRate;
   double reportHeartbeatRate;


### PR DESCRIPTION
Precisely what the title says. Built on top of #25. To be rebased and reviewed after it.