### PR TITLE
fix python roslint error in mission_logger package

### DIFF
--- a/mission_logger/src/mission_logger/mission_bag_recorder.py
+++ b/mission_logger/src/mission_logger/mission_bag_recorder.py
@@ -8,6 +8,7 @@ import rospy
 from .common import textindent
 from .mission_logger import MissionLogger
 
+
 class MissionBagRecorder(MissionLogger):
 
     Recording = collections.namedtuple('Recording', ['subprocess'])


### PR DESCRIPTION
This patch  fixes a roslint error (It's not huge, just a small one).