### PR TITLE
Misc fixes to the mission_logger package

### DIFF
--- a/mission_logger/src/mission_logger/mission_bag_recorder.py
+++ b/mission_logger/src/mission_logger/mission_bag_recorder.py
@@ -27,7 +27,8 @@ class MissionBagRecorder(MissionLogger):
             subprocess.Popen(
                 cmd, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                cwd=self._log_directory
+                cwd=self._log_directory,
+                preexec_fn=os.setsid,
             )
         )
 
@@ -37,7 +38,8 @@ class MissionBagRecorder(MissionLogger):
     def _stop(self, recording):
         p = recording.subprocess
         if p.poll() is None:
-            p.send_signal(signal.SIGINT)
+            pgrp = os.getpgid(p.pid)
+            os.killpg(pgrp, signal.SIGINT)
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             rospy.logerr('rosbag record finished with nonzero exit code %d', p.returncode)

--- a/mission_logger/src/mission_logger/mission_logger.py
+++ b/mission_logger/src/mission_logger/mission_logger.py
@@ -49,7 +49,7 @@ class MissionLogger(object):
 
     def spin(self):
         mission_state_subscriber = rospy.Subscriber(
-            "/mission_manager/report_execute_mission_state",
+            "/mngr/report_mission_execute_state",
             ReportExecuteMissionState, self._on_mission_state_change
         )
         try:


### PR DESCRIPTION
This pull request fixes two unrelated bugs in the `mission_logger` package:

- `mission_manager`'s mission state topic, as expected by any `mission_logger.MissionLogger`, was incorrect.
- `mission_logger.MissionBagLogger.stop()` did not take into account that `rosbag` spins up its own subprocesses.

To be rebased or plain merged, not squashed.