### PR TITLE
[WIP] Redundancies in error check and handling

### DIFF
--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -183,7 +183,8 @@ void AutoPilotNode::correctedDataCallback(const pose_estimator::CorrectedData& d
 void AutoPilotNode::missionStatusCallback(const mission_manager::ReportExecuteMissionState& data)
 {
   using mission_manager::ReportExecuteMissionState;
-  if (data.execute_mission_state == ReportExecuteMissionState::COMPLETE)
+  if (data.execute_mission_state == ReportExecuteMissionState::COMPLETE ||
+      data.execute_mission_state == ReportExecuteMissionState::ABORTING)
   {
     boost::mutex::scoped_lock lock(m_mutex);
     missionMode = true;

--- a/fin_control/CMakeLists.txt
+++ b/fin_control/CMakeLists.txt
@@ -39,7 +39,7 @@ catkin_package(
 roslint_cpp(
   src/fin_control.cpp
   src/fin_control_main.cpp
-  include/fin_control.h
+  include/fin_control/fin_control.h
 )
 
 roslint_add_test()

--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -38,8 +38,8 @@
  * fin_control.h
  */
 
-#ifndef FIN_CONTROL_H
-#define FIN_CONTROL_H
+#ifndef FIN_CONTROL_FIN_CONTROL_H
+#define FIN_CONTROL_FIN_CONTROL_H
 
 #define NUM_FINS 4
 #define NODE_VERSION "1.8x"
@@ -63,6 +63,7 @@
 #include <fin_control/SetAngle.h>
 #include <fin_control/SetAngles.h>
 #include <health_monitor/ReportFault.h>
+#include <rosmon_msgs/State.h>
 
 #include "dynamixel_workbench_msgs/DynamixelCommand.h"
 #include "dynamixel_workbench_msgs/DynamixelInfo.h"
@@ -99,6 +100,7 @@ class FinControl
   void handleSetAngle(const fin_control::SetAngle::ConstPtr& msg);
   void handleSetAngles(const fin_control::SetAngles::ConstPtr& msg);
   void handleEnableReportAngles(const fin_control::EnableReportAngles::ConstPtr& msg);
+  void handle_rosmonFaults(const rosmon_msgs::State& msg);
 
   double maxCtrlFinAngle;
   double ctrlFinOffset;
@@ -112,6 +114,7 @@ class FinControl
   ros::Subscriber subscriber_setAngle;
   ros::Subscriber subscriber_setAngles;
   ros::Subscriber subscriber_enableReportAngles;
+  ros::Subscriber subscriber_rosmonFaults;
   ros::Publisher publisher_reportAngle;
 
   DynamixelWorkbench myWorkBench;
@@ -128,4 +131,4 @@ class FinControl
 }  // namespace robot
 }  // namespace qna
 
-#endif  // FIN_CONTROL_H
+#endif  // FIN_CONTROL_FIN_CONTROL_H

--- a/fin_control/src/fin_control.cpp
+++ b/fin_control/src/fin_control.cpp
@@ -411,5 +411,25 @@ void FinControl::Stop()
   m_thread->join();
 }
 
+void FinControl::handle_rosmonFaults(const rosmon_msgs::State& msg)
+{
+  for (int i = 0; i < msg.nodes.size(); i++)
+  {
+    if (msg.nodes[i].state == rosmon_msgs::NodeState::CRASHED)
+    {
+      if (msg.nodes[i].name == "autopilot_node")
+      {
+        double maxCtrlFinAngleRadians = degreesToRadians(maxCtrlFinAngle);
+        fin_control::SetAngles::Ptr finAnglesToSurface;
+        finAnglesToSurface->f1_angle_in_radians = maxCtrlFinAngleRadians;
+        finAnglesToSurface->f2_angle_in_radians = maxCtrlFinAngleRadians;
+        finAnglesToSurface->f3_angle_in_radians = -maxCtrlFinAngleRadians;
+        finAnglesToSurface->f4_angle_in_radians = -maxCtrlFinAngleRadians;
+        handleSetAngles(finAnglesToSurface);
+      }
+    }
+  }
+}
+
 }  // namespace robot
 }  // namespace qna

--- a/thruster_control/include/thruster_control/thruster_control.h
+++ b/thruster_control/include/thruster_control/thruster_control.h
@@ -49,6 +49,8 @@
 #include <diagnostic_tools/periodic_message_status.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <health_monitor/ReportFault.h>
+#include <rosmon_msgs/State.h>
+#include <mission_manager/ReportExecuteMissionState.h>
 #include <thruster_control/ReportMotorTemperature.h>
 #include <thruster_control/ReportRPM.h>
 #include <thruster_control/SetRPM.h>
@@ -88,14 +90,17 @@ class ThrusterControl
   double maxAllowedMotorRPM;
 
   void handle_SetRPM(const thruster_control::SetRPM::ConstPtr& msg);
+  void handle_rosmonFaults(const rosmon_msgs::State& msg);
 
   ros::NodeHandle& nodeHandle;
 
   ros::Subscriber subscriber_setRPM;
+  ros::Subscriber subscriber_rosmonFaults;
 
   diagnostic_tools::DiagnosedPublisher<thruster_control::ReportRPM> publisher_reportRPM;
   diagnostic_tools::DiagnosedPublisher<thruster_control::ReportMotorTemperature>
       publisher_reportMotorTemp;
+  ros::Publisher publisher_MissionStateAbort;
 
   diagnostic_tools::HealthCheck<double> motorRPMCheck;
   diagnostic_tools::HealthCheck<double> motorTemperatureCheck;


### PR DESCRIPTION
This patch adds redundance in error hangling (set fins to surface, and set the thruster velocity to 0 rpm) if mission manager, autopilot or health monitor have crashed.

**Thruster Control Node:**
The Thruster control node is subscribing to rosmon/state. If the health monitor node or mission manager node have crashed:
- Thruster control node sets the RPM to 0,
- Thruster control publish an abort mission msg on /mngr/report_mission_execute_state topic which is subscibed by Autopilot. Then autopilot sets fins to surface.

**Fin Control Node:**
The Fin Control is subscribing to rosmon/state. If the autopilot node has crashed:
- Set the fins to surface,
- Health Monitor detects that autopilot has crashed and sends to mission manager the error. Then the Mission Manager node aborts the mission and sets the thruster velocity to 0.