### PR TITLE
Avoid mission_logger.MissionTextLogger subprocesses' output buffering

### DIFF
--- a/mission_logger/src/mission_logger/mission_text_logger.py
+++ b/mission_logger/src/mission_logger/mission_text_logger.py
@@ -39,8 +39,10 @@ class MissionTextLogger(MissionLogger):
             output_filename = topic.strip('/').replace('/', '_') + '.txt'
             output_filepath = os.path.join(output_directory, output_filename)
             output_file = open(output_filepath, 'w')
+            env = os.environ.copy()
+            env['PYTHONUNBUFFERED'] = '1'  # avoid output buffering
             recording.subprocesses.append(subprocess.Popen(
-                ['rostopic', 'echo', '-p', topic],
+                ['rostopic', 'echo', '-p', topic], env=env,
                 stdout=output_file, stderr=subprocess.PIPE,
             ))
             recording.files.append(output_file)


### PR DESCRIPTION
As reported by @ChrisScianna, text logging output files often end up empty. I'm unable to reproduce locally, so this patch is an educated guess.