### PR TITLE
Redundancies in error handling

### DIFF
--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -408,7 +408,7 @@ void AutoPilotNode::workerFunc()
       if (missionMode)
         mixActuators(rollCmdPos, pitchCmdPos, yawCmdPos);
       else
-        mixActuators(0, 0, 0);
+        mixActuators(0, -maxCtrlFinAngle, 0);    //fin to surface
 
       // SPEED
       setRPM.commanded_rpms = desiredSpeed * rpmPerKnot;

--- a/health_monitor/launch/health_monitor.launch
+++ b/health_monitor/launch/health_monitor.launch
@@ -3,7 +3,7 @@
   <arg name="minReportFaultsRate" default="0.5"/>
   <arg name="maxReportFaultsRate" default="2.0"/>
 
-  <node name="health_monitor_node" pkg="health_monitor" type="health_monitor_node" output="screen">
+  <node name="health_monitor_node" pkg="health_monitor" type="health_monitor_node" output="screen" required="true">
     <param name="report_faults_rate" type="double" value="$(arg reportFaultsRate)"/>
     <param name="min_report_faults_rate" type="double" value="$(arg minReportFaultsRate)"/>
     <param name="max_report_faults_rate" type="double" value="$(arg maxReportFaultsRate)"/>


### PR DESCRIPTION
This patch:
- Shutdown the system on health_monitor crash.
- Force fins to surface angle and thruster to 0 RPM on autopilot startup

If mission manager node has crashed then heartbeat won't be updated. Therefore autopilot will force fins to surface angle and thruster to 0 RPM.
