### PR TITLE
Fix bug: roslint file list to test in the fin_control package

### DIFF
--- a/fin_control/CMakeLists.txt
+++ b/fin_control/CMakeLists.txt
@@ -39,10 +39,8 @@ catkin_package(
 roslint_cpp(
   src/fin_control.cpp
   src/fin_control_main.cpp
-  include/fin_control.h
+  include/fin_control/fin_control.h
 )
-
-roslint_add_test()
 
 ###########
 ## Build ##
@@ -79,3 +77,8 @@ install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+#############
+## Testing ##
+#############
+
+roslint_add_test()

--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -38,8 +38,8 @@
  * fin_control.h
  */
 
-#ifndef FIN_CONTROL_H
-#define FIN_CONTROL_H
+#ifndef FIN_CONTROL_FIN_CONTROL_H
+#define FIN_CONTROL_FIN_CONTROL_H
 
 #define NUM_FINS 4
 #define NODE_VERSION "1.8x"
@@ -128,4 +128,4 @@ class FinControl
 }  // namespace robot
 }  // namespace qna
 
-#endif  // FIN_CONTROL_H
+#endif  // FIN_CONTROL_FIN_CONTROL_H


### PR DESCRIPTION
This patch:
- Fix the path of the fin_control.h file in the roslint test on the CMakeList.
- Add Testing block in CMakeList.
- Fix roslint errors marked by roslint.