### PR TITLE
Refactor mission_text_logger implementation

### DIFF
--- a/mission_logger/package.xml
+++ b/mission_logger/package.xml
@@ -13,6 +13,8 @@
   <build_depend>roslint</build_depend>
   <exec_depend>mission_manager</exec_depend>
   <exec_depend>rosgraph</exec_depend>
+  <exec_depend>roslib</exec_depend>
+  <exec_depend>rostopic</exec_depend>
   <exec_depend>python-rospkg</exec_depend>
   <exec_depend>rospy</exec_depend>
 </package>

--- a/mission_logger/src/mission_logger/mission_bag_recorder.py
+++ b/mission_logger/src/mission_logger/mission_bag_recorder.py
@@ -1,5 +1,6 @@
 import os
 import collections
+import datetime
 import subprocess
 import signal
 
@@ -17,12 +18,19 @@ class MissionBagRecorder(MissionLogger):
         super(MissionBagRecorder, self).__init__(name, anonymous=anonymous)
 
     def _start(self, mission_id):
-        bag_prefix = 'mission_{}'.format(mission_id)
-        cmd = ['rosbag', 'record', '-o', bag_prefix]
+        now = datetime.datetime.now()
+        bag_name = 'mission_{}_{}.bag'.format(
+            mission_id, now.strftime('%Y%m%d_%H%M%S')
+        )
+        cmd = ['rosbag', 'record', '-O', bag_name]
         if self._topics:
             cmd.extend(self._topics)
         else:
             cmd.append('--all')
+        rospy.loginfo(
+            "Bagfile '%s' for mission %d to be written to '%s'",
+            bag_name, mission_id, self._log_directory
+        )
         return MissionBagRecorder.Recording(
             subprocess.Popen(
                 cmd, stdout=subprocess.PIPE,

--- a/mission_logger/src/mission_logger/mission_logger.py
+++ b/mission_logger/src/mission_logger/mission_logger.py
@@ -17,6 +17,10 @@ class MissionLogger(object):
     def __init__(self, *args, **kwargs):
         rospy.init_node(*args, **kwargs)
         self._topics = rospy.get_param('~topics', [])
+        self._topics = [
+            rospy.resolve_name(topic_name)
+            for topic_name in self._topics
+        ]
         self._check_period = rospy.get_param('~check_period', 0.1)
         self._log_directory = rospy.get_param(
             '~log_directory', rospkg.get_log_dir()


### PR DESCRIPTION
This pull request mainly refactors the mission text logger to use in-process Subscribers, as opposed to separate `rostopic echo` CLI instances. 

Tested it locally by manually mocking a mission.