### PR TITLE
Make health_monitor publish faults at a fixed rate only

### DIFF
--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -114,7 +114,6 @@ void HealthMonitor::handle_diagnostics(const diagnostic_msgs::DiagnosticArrayPtr
     if (errorValues != 0)
     {
         setFault(errorValues);
-        sendFaults();
     }
 }
 
@@ -140,7 +139,6 @@ void HealthMonitor::handle_rosmonFaults(const rosmon_msgs::State &msg)
     if (errorValues != 0)
     {
         setFault(errorValues);
-        sendFaults();
     }
 }
 


### PR DESCRIPTION
Precisely what the title says. It messes up with rate checks.