### PR TITLE
Modify report angle message structure

### DIFF
--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -81,7 +81,6 @@ class FinControl
   ros::Timer reportAngleTimer;
   void reportAngleSendTimeout(const ros::TimerEvent& timer);
   void reportAngles();
-  void reportAngle(uint8_t id);
 
  private:
   boost::shared_ptr<boost::thread> m_thread;

--- a/fin_control/msg/ReportAngle.msg
+++ b/fin_control/msg/ReportAngle.msg
@@ -1,3 +1,2 @@
 std_msgs/Header header
-uint8   ID
-float32 angle_in_radians
+float32[] angles_in_radians

--- a/jaus_ros_bridge/src/ReportFinDeflection.cpp
+++ b/jaus_ros_bridge/src/ReportFinDeflection.cpp
@@ -93,9 +93,9 @@ void ReportFinDeflection::handleReportAngle(const fin_control::ReportAngle::Cons
 
   if (!TimeToSend(_beginTime, clock())) return;
 
-  if (_finId != msg->ID) return;  // do not handle this msg if it's a different finID
+  if (_finId >= msg->angles_in_radians.size()) return;  // Id out of scope.
 
-  float f_angle = JausDataManager::radiansToDegrees(msg->angle_in_radians);
+  float f_angle = JausDataManager::radiansToDegrees(msg->angles_in_radians[_finId]);
   if (f_angle < 0)
     f_angle -= .5;
   else


### PR DESCRIPTION
The fin_control node reports fin angles multiplexing the ID/angle.

This PR:
- Modify the structure of the ReportAngles.msg to use Vector type msg instead of ID/Angle
- Modify the Jaus Ros Bridge to allow this implementation.