### PR TITLE
[POC] Enable thruster_control unit testing

### DIFF
--- a/thruster_control/CMakeLists.txt
+++ b/thruster_control/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(thruster_control)
-
-set(NODE_APP_NAME ${PROJECT_NAME}_node)
+project(thruster_control )
 
 add_compile_options(-std=c++11)
 
@@ -47,49 +45,44 @@ set(CANFESTIVAL_INCLUDES
     $ENV{CANFESTIVALHOME}/include/
 )
 
+set(CANFESTIVAL_LIBRARIES
+  $ENV{CANFESTIVALHOME}/lib/libcanfestival.a
+  $ENV{CANFESTIVALHOME}/lib/libcanfestival_unix.a
+  $ENV{CANFESTIVALHOME}/lib/libcanfestival_can_socket.a
+)
+
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${CANFESTIVAL_INCLUDES}
 )
 
-add_executable(${NODE_APP_NAME}
-   src/thruster_control.cpp
-   src/thruster_control_main.cpp
-   src/CANIntf.cpp
-   src/CO_VehicleSBC.c
-)
-
-add_dependencies(${NODE_APP_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-set(CANFESTIVAL_LIBRARIES
-    $ENV{CANFESTIVALHOME}/lib/libcanfestival.a
-    $ENV{CANFESTIVALHOME}/lib/libcanfestival_unix.a
-    $ENV{CANFESTIVALHOME}/lib/libcanfestival_can_socket.a
-)
-
-target_include_directories(${NODE_APP_NAME} PUBLIC
-    ${CANFESTIVAL_INCLUDES})
-
- target_link_libraries(${NODE_APP_NAME}
-   ${catkin_LIBRARIES}
-   ${CANFESTIVAL_LIBRARIES}
-    rt
-    dl
-    pthread
- )
-
-roslint_cpp(
+add_library(${PROJECT_NAME} STATIC
   src/thruster_control.cpp
-  src/thruster_control_main.cpp
-  include/thruster_control/thruster_control.h
+  src/thruster_control_ros.cpp
+  src/CANIntf.cpp
+  src/CO_VehicleSBC.c
 )
+
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${CANFESTIVAL_LIBRARIES}
+  rt
+  dl
+  pthread
+)
+
+add_executable(${PROJECT_NAME}_node src/thruster_control_main.cpp)
+
+target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 #############
 ## Install ##
 #############
 
-install(TARGETS ${NODE_APP_NAME}
+install(TARGETS ${PROJECT_NAME}_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -104,4 +97,20 @@ install(FILES
 ## Testing ##
 #############
 
-roslint_add_test()
+if (CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest_gmock(test_thruster_control_ros
+    test/thruster_control_ros.test
+    test/test_thruster_control_ros.cpp)
+  target_link_libraries(test_thruster_control_ros ${PROJECT_NAME})
+
+  roslint_cpp(
+    src/thruster_control.cpp
+    src/thruster_control_ros.cpp
+    src/thruster_control_main.cpp
+    include/thruster_control/thruster_control.h
+    include/thruster_control/thruster_control_ros.h
+  )
+
+   roslint_add_test()
+endif()

--- a/thruster_control/include/thruster_control/thruster_control_ros.h
+++ b/thruster_control/include/thruster_control/thruster_control_ros.h
@@ -1,0 +1,129 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+// Original version: Christopher Scianna Christopher.Scianna@us.QinetiQ.com
+
+/*
+ * thruster_control.h
+ */
+
+#ifndef THRUSTER_CONTROL_THRUSTER_CONTROL_ROS_H
+#define THRUSTER_CONTROL_THRUSTER_CONTROL_ROS_H
+
+#include <cmath>
+#include <memory>
+
+#include <ros/ros.h>
+#include <diagnostic_tools/diagnosed_publisher.h>
+#include <diagnostic_tools/health_check.h>
+#include <diagnostic_tools/message_stagnation_check.h>
+#include <diagnostic_tools/periodic_message_status.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <sensor_msgs/BatteryState.h>
+#include <health_monitor/ReportFault.h>
+#include <thruster_control/ReportMotorTemperature.h>
+#include <thruster_control/ReportRPM.h>
+#include <thruster_control/SetRPM.h>
+#include "thruster_control/CANIntf.h"
+#include "thruster_control/thruster_control.h"
+
+namespace qna
+{
+namespace robot
+{
+std::unique_ptr<CANIntf> ConfigureCANInterfaceUsingROSParams(ros::NodeHandle nh);
+
+class ThrusterControlROS
+{
+public:
+  ThrusterControlROS();
+  ThrusterControlROS(const ros::NodeHandle& nh, const ros::NodeHandle& pnh);
+  ThrusterControlROS(std::unique_ptr<ThrusterControlInterface> thruster_control);
+  ThrusterControlROS(const ros::NodeHandle& nh, const ros::NodeHandle& pnh,
+                     std::unique_ptr<ThrusterControlInterface> thruster_control);
+
+  void MonitorMotorRPMUsing(diagnostic_updater::Updater* updater);
+  void MonitorMotorTemperatureUsing(diagnostic_updater::Updater* updater);
+  void MonitorBatteryHealthUsing(diagnostic_updater::Updater* updater);
+  void MonitorUsing(diagnostic_updater::Updater* updater);
+
+private:
+  void OnReportMotorRPMTimeout(const ros::TimerEvent& event);
+  void OnReportMotorTemperatureTimeout(const ros::TimerEvent& event);
+  void OnReportBatteryHealthTimeout(const ros::TimerEvent& event);
+  void OnMotorRPMSet(const thruster_control::SetRPM::ConstPtr& message);
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle pnh_;
+  std::unique_ptr<ThrusterControlInterface> thruster_control_;
+
+  ros::Subscriber motor_rpm_subscriber_;
+  diagnostic_tools::DiagnosedPublisher<
+    thruster_control::ReportRPM> motor_rpm_publisher_;
+  diagnostic_tools::DiagnosedPublisher<
+    thruster_control::ReportMotorTemperature> motor_temperature_publisher_;
+  diagnostic_tools::DiagnosedPublisher<
+    sensor_msgs::BatteryState> battery_health_publisher_;
+
+  double report_motor_rpm_period_;
+  ros::Timer report_motor_rpm_timer_;
+
+  double report_battery_health_period_;
+  ros::Timer report_motor_temperature_timer_;
+
+  double report_motor_temperature_period_;
+  ros::Timer report_battery_health_timer_;
+
+  diagnostic_tools::TopicDiagnosticTask<
+    thruster_control::ReportRPM>* report_motor_rpm_rate_check_{nullptr};
+  diagnostic_tools::HealthCheck<double> motor_rpm_check_;
+
+  diagnostic_tools::TopicDiagnosticTask<
+    thruster_control::ReportMotorTemperature>* motor_temperature_rate_check_{nullptr};
+  diagnostic_tools::TopicDiagnosticTask<
+    thruster_control::ReportMotorTemperature>* motor_temperature_stagnation_check_{nullptr};
+  diagnostic_tools::HealthCheck<double> motor_temperature_check_;
+
+  diagnostic_tools::TopicDiagnosticTask<
+    sensor_msgs::BatteryState>* battery_health_rate_check_{nullptr};
+  diagnostic_tools::TopicDiagnosticTask<
+    sensor_msgs::BatteryState>* battery_health_stagnation_check_{nullptr};
+  diagnostic_tools::HealthCheck<double> battery_total_current_check_;
+  diagnostic_tools::HealthCheck<double> battery_cell_voltage_check_;
+};
+
+}  // namespace robot
+}  // namespace qna
+
+#endif  // THRUSTER_CONTROL_THRUSTER_CONTROL_ROS_H

--- a/thruster_control/package.xml
+++ b/thruster_control/package.xml
@@ -29,4 +29,5 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/thruster_control/src/thruster_control.cpp
+++ b/thruster_control/src/thruster_control.cpp
@@ -41,286 +41,72 @@
 
 #include "thruster_control/thruster_control.h"
 
+#include <cmath>
 #include <string>
 
 namespace qna
 {
 namespace robot
 {
-const double RPM_TO_RADSEC = 3.1415 / 30.0;
-const double RADSEC_TO_RPM = 30.0 / 3.1415;
-
-ThrusterControl::ThrusterControl(ros::NodeHandle& nodeHandle)
-    : nodeHandle(nodeHandle), diagnosticsUpdater(nodeHandle)
+namespace
 {
-  using health_monitor::ReportFault;
 
-  diagnosticsUpdater.setHardwareID("thruster");
+constexpr double RPM_TO_RADSEC = M_PI / 30.0;
+constexpr double RADSEC_TO_RPM = 30.0 / M_PI;
 
-  reportRPMRate = 0.1;
-  reportMotorTemperatureRate = 0.5;
-  minReportRPMRate = reportRPMRate / 2.0;
-  maxReportRPMRate = reportRPMRate * 2.0;
-  minReportMotorTemperatureRate = reportMotorTemperatureRate / 2.0;
-  maxReportMotorTemperatureRate = reportMotorTemperatureRate * 2.0;
-  reportBatteryHealthRate = 1.0;
-  minReportBatteryHealthRate = reportBatteryHealthRate / 2.0;
-  maxReportBatteryHealthRate = reportBatteryHealthRate * 2.0;
-  setRPMTimeout = 0.5;  // 0.5 seconds, 500 milliseconds
-  currentLoggingEnabled = false;
-  std::string canNodeId1 = "";  // TODO(QNA) what should the default be??
-  std::string canNodeId2 = "";
-  motorTemperatureThreshold = 50;
-  maxAllowedMotorRPM = 0;
-  minBatteryTotalCurrent = 5000;
-  double motorTemperatureSteadyBand = 0.0;
-  double batteryCurrentSteadyBand = 0.0;
-  double minBatteryCellVoltage = 30;  // in V
+double convertRPMToRadSec(double rpms) { return rpms * RPM_TO_RADSEC; }
+double convertRadSecToRPM(double radsec) { return radsec * RADSEC_TO_RPM; }
 
-  nodeHandle.getParam("/thruster_control_node/report_rpm_rate", reportRPMRate);
-  nodeHandle.getParam("/thruster_control_node/min_report_rpm_rate", minReportRPMRate);
-  nodeHandle.getParam("/thruster_control_node/max_report_rpm_rate", maxReportRPMRate);
-  nodeHandle.getParam("/thruster_control_node/report_motor_temperature_rate",
-                      reportMotorTemperatureRate);
-  nodeHandle.getParam("/thruster_control_node/min_report_motor_temperature_rate",
-                      minReportMotorTemperatureRate);
-  nodeHandle.getParam("/thruster_control_node/max_report_motor_temperature_rate",
-                      maxReportMotorTemperatureRate);
-  nodeHandle.getParam("/thruster_control_node/report_battery_health_rate",
-                      reportBatteryHealthRate);
-  nodeHandle.getParam("/thruster_control_node/min_report_battery_health_rate",
-                      minReportBatteryHealthRate);
-  nodeHandle.getParam("/thruster_control_node/max_report_battery_health_rate",
-                      maxReportBatteryHealthRate);
-  nodeHandle.getParam("/thruster_control_node/battery_current_steady_band",
-                      batteryCurrentSteadyBand);
-  nodeHandle.getParam("/thruster_control_node/set_rpm_timeout_seconds", setRPMTimeout);
-  nodeHandle.getParam("/thruster_control_node/current_logging_enabled", currentLoggingEnabled);
-  nodeHandle.getParam("/thruster_control_node/can_node_id_1", canNodeId1);
-  nodeHandle.getParam("/thruster_control_node/can_node_id_2", canNodeId2);
-  nodeHandle.getParam("/thruster_control_node/max_allowed_motor_rpm", maxAllowedMotorRPM);
-  nodeHandle.getParam("/thruster_control_node/motor_temperature_threshold",
-                      motorTemperatureThreshold);
-  nodeHandle.getParam("/thruster_control_node/motor_temperature_steady_band",
-                      motorTemperatureSteadyBand);
-  nodeHandle.getParam("/thruster_control_node/min_battery_total_current", minBatteryTotalCurrent);
-  nodeHandle.getParam("/thruster_control_node/min_battery_cell_voltage", minBatteryCellVoltage);
+}  // namespace
 
-  ROS_DEBUG_STREAM("report_rpm_rate set to " << reportRPMRate);
-  ROS_DEBUG_STREAM("report_motor_temperatuere_rate set to  " << reportMotorTemperatureRate);
-  ROS_DEBUG_STREAM("report_battery_health_rate set to  " << reportBatteryHealthRate);
-  ROS_DEBUG_STREAM("set_rpm_timeout_seconds set to  " << setRPMTimeout);
-  ROS_DEBUG_STREAM("current_logging_enabled set to  " << currentLoggingEnabled ? "true" : "false");
-  ROS_DEBUG_STREAM("CAN Node 1 Id =  " << canNodeId1);
-  ROS_DEBUG_STREAM("CAN Node 2 Id =  " << canNodeId2);
-  ROS_DEBUG_STREAM("Minimum Battery Total Current = " << minBatteryTotalCurrent);
-  ROS_INFO("Minimum Battery Cell Voltage:[%lf]", minBatteryCellVoltage);
-
-  subscriber_setRPM =
-      nodeHandle.subscribe("/thruster_control/set_rpm", 1, &ThrusterControl::handle_SetRPM, this);
-
-  canIntf.SetMotorTimeoutSeconds(setRPMTimeout);
-  canIntf.SetEnableCANLogging(currentLoggingEnabled);
-  canIntf.AddCanNodeIdToList(canNodeId1);
-  canIntf.AddCanNodeIdToList(canNodeId2);
-
-  publisher_reportBatteryHealth = diagnostic_tools::create_publisher<sensor_msgs::BatteryState>(
-      nodeHandle, "/thruster_control/report_battery_health", 1);
-
-  diagnostic_tools::PeriodicMessageStatusParams paramsReportsBatteryHealthCheckPeriod{};
-  paramsReportsBatteryHealthCheckPeriod.min_acceptable_period(minReportBatteryHealthRate);
-  paramsReportsBatteryHealthCheckPeriod.max_acceptable_period(maxReportBatteryHealthRate);
-  diagnostic_tools::Diagnostic diagnosticBatteryHealthInfoStale(diagnostic_tools::Diagnostic::WARN,
-                                                                ReportFault::BATTERY_INFO_STALE);
-  paramsReportsBatteryHealthCheckPeriod.abnormal_diagnostic(diagnosticBatteryHealthInfoStale);
-  diagnosticsUpdater.add(
-      publisher_reportBatteryHealth.add_check<diagnostic_tools::PeriodicMessageStatus>(
-          "rate check", paramsReportsBatteryHealthCheckPeriod));
-
-  diagnostic_tools::MessageStagnationCheckParams paramsBatteryMessageStagnationcheck;
-  diagnostic_tools::Diagnostic diagnosticBatteryInfoStagnate(
-      diagnostic_tools::Diagnostic::WARN, ReportFault::BATTERY_INFO_STAGNATED);
-  paramsBatteryMessageStagnationcheck.stagnation_diagnostic(diagnosticBatteryInfoStagnate);
-
-  diagnosticsUpdater.add(
-      publisher_reportBatteryHealth.add_check<diagnostic_tools::MessageStagnationCheck>(
-          "stagnation check",
-          [batteryCurrentSteadyBand](const sensor_msgs::BatteryState& a,
-                                     const sensor_msgs::BatteryState& b)
-          {
-            return std::fabs(a.current - b.current) < batteryCurrentSteadyBand;
-          }
-          , paramsBatteryMessageStagnationcheck));
-
-
-  batteryCurrentCheck = diagnostic_tools::create_health_check<double>(
-      "Battery Current check", [this](double batteryCurrent) -> diagnostic_tools::Diagnostic
-      {
-        using diagnostic_tools::Diagnostic;
-        if (batteryCurrent < minBatteryTotalCurrent)
-        {
-          return Diagnostic(Diagnostic::WARN, ReportFault::BATTERY_CURRENT_THRESHOLD_REACHED)
-              .description("Total current - NOT OK (%f mA < %f mA)", batteryCurrent,
-                           minBatteryTotalCurrent);
-        }
-        return Diagnostic::OK;
-      }
-);
-  diagnosticsUpdater.add(batteryCurrentCheck);
-
-  batteryVoltageCheck = diagnostic_tools::create_health_check<double>(
-      "Battery Voltage check",
-      [minBatteryCellVoltage](double batteryVoltage) -> diagnostic_tools::Diagnostic
-      {
-        using diagnostic_tools::Diagnostic;
-        if (batteryVoltage < minBatteryCellVoltage)
-        {
-          return Diagnostic(Diagnostic::WARN, ReportFault::BATTERY_CURRENT_THRESHOLD_REACHED)
-              .description("Battery Votlage - NOT OK (%f V < %f V)", batteryVoltage,
-                           minBatteryCellVoltage);
-        }
-        return Diagnostic::OK;
-      }
-);
-  diagnosticsUpdater.add(batteryVoltageCheck);
-
-  publisher_reportRPM = diagnostic_tools::create_publisher<thruster_control::ReportRPM>(
-      nodeHandle, "/thruster_control/report_rpm", 1);
-  diagnostic_tools::PeriodicMessageStatusParams paramsReportsRPMCheckPeriod{};
-  paramsReportsRPMCheckPeriod.min_acceptable_period(minReportRPMRate);
-  paramsReportsRPMCheckPeriod.max_acceptable_period(maxReportRPMRate);
-  diagnostic_tools::Diagnostic diagnosticRPMInfoStale(diagnostic_tools::Diagnostic::WARN,
-                                                      ReportFault::THRUSTER_RPM_STALE);
-  paramsReportsRPMCheckPeriod.abnormal_diagnostic(diagnosticRPMInfoStale);
-  diagnosticsUpdater.add(publisher_reportRPM.add_check<diagnostic_tools::PeriodicMessageStatus>(
-      "rate check", paramsReportsRPMCheckPeriod));
-
-  publisher_reportMotorTemp =
-      diagnostic_tools::create_publisher<thruster_control::ReportMotorTemperature>(
-          nodeHandle, "/thruster_control/report_motor_temperature", 1);
-  diagnostic_tools::PeriodicMessageStatusParams paramsReportsTemperatureCheckPeriod{};
-  paramsReportsTemperatureCheckPeriod.min_acceptable_period(minReportMotorTemperatureRate);
-  paramsReportsTemperatureCheckPeriod.max_acceptable_period(maxReportMotorTemperatureRate);
-  diagnostic_tools::Diagnostic diagnosticTemperatureInfoStale(diagnostic_tools::Diagnostic::WARN,
-                                                              ReportFault::THRUSTER_TEMP_STALE);
-  paramsReportsTemperatureCheckPeriod.abnormal_diagnostic(diagnosticTemperatureInfoStale);
-  diagnosticsUpdater.add(
-      publisher_reportMotorTemp.add_check<diagnostic_tools::PeriodicMessageStatus>(
-          "rate check", paramsReportsTemperatureCheckPeriod));
-
-  diagnostic_tools::MessageStagnationCheckParams paramsTemperatureMessageStagnationcheck;
-  diagnostic_tools::Diagnostic diagnosticTemperatureInfoStagnate(
-      diagnostic_tools::Diagnostic::WARN, ReportFault::THRUSTER_TEMP_STAGNATED);
-  paramsTemperatureMessageStagnationcheck.stagnation_diagnostic(diagnosticTemperatureInfoStagnate);
-
-  diagnosticsUpdater.add(
-      publisher_reportMotorTemp.add_check<diagnostic_tools::MessageStagnationCheck>(
-          "stagnation check",
-          [motorTemperatureSteadyBand](const thruster_control::ReportMotorTemperature& a,
-                                       const thruster_control::ReportMotorTemperature& b)
-          {
-            return std::fabs(a.motor_temp - b.motor_temp < motorTemperatureSteadyBand);
-          }
-          , paramsTemperatureMessageStagnationcheck));
-
-  canIntf.SetMotorTimeoutSeconds(setRPMTimeout);
-  canIntf.SetEnableCANLogging(currentLoggingEnabled);
-
-  motorRPMCheck = diagnostic_tools::create_health_check<double>(
-      "Motor RPM check", [this](double rpms) -> diagnostic_tools::Diagnostic
-      {
-        using diagnostic_tools::Diagnostic;
-        if (std::abs(rpms) > maxAllowedMotorRPM)
-        {
-          return Diagnostic(Diagnostic::WARN, ReportFault::THRUSTER_RPM_THRESHOLD_REACHED)
-              .description("Absolute RPMs above threshold: |%f| > %f", rpms, maxAllowedMotorRPM);
-        }
-        return Diagnostic::OK;
-      }
-);
-  diagnosticsUpdater.add(motorRPMCheck);
-
-  motorTemperatureCheck = diagnostic_tools::create_health_check<double>(
-      "Motor temperature check", [this](double temperature) -> diagnostic_tools::Diagnostic
-      {
-        using diagnostic_tools::Diagnostic;
-        if (temperature > motorTemperatureThreshold)
-        {
-          return Diagnostic(Diagnostic::ERROR, ReportFault::THRUSTER_TEMP_THRESHOLD_REACHED)
-              .description("Temperature above threshold: %f degC > %f degC", temperature,
-                           motorTemperatureThreshold);
-        }
-        return Diagnostic::OK;
-      }
-);
-  diagnosticsUpdater.add(motorTemperatureCheck);
-
-  reportRPMTimer = nodeHandle.createTimer(ros::Duration(reportRPMRate),
-                                          &ThrusterControl::reportRPMSendTimeout, this);
-  reportMotorTempTimer = nodeHandle.createTimer(ros::Duration(reportMotorTemperatureRate),
-                                                &ThrusterControl::reportMotorTempSendTimeout, this);
-  reportBatteryHealthTimer =
-      nodeHandle.createTimer(ros::Duration(reportBatteryHealthRate),
-                             &ThrusterControl::reportBatteryHealthSendTimeout, this);
-  canIntf.Init();
+ThrusterControl::ThrusterControl(std::unique_ptr<CANIntf> can_interface)
+  : can_interface_(std::move(can_interface))
+{
+  can_interface_->Init();
 }
 
-ThrusterControl::~ThrusterControl() {}
-
-void ThrusterControl::reportRPMSendTimeout(const ros::TimerEvent& timer)
+thruster_control::ReportRPM ThrusterControl::GetMotorRPM()
 {
-  thruster_control::ReportRPM message;
-
-  message.header.stamp = ros::Time::now();
-  message.rpms = convertRadSecToRPM(canIntf.velocity_feedback_radsec.Get());
-  motorRPMCheck.test(message.rpms);
-
-  publisher_reportRPM.publish(message);
-  diagnosticsUpdater.update();
+  thruster_control::ReportRPM msg;
+  msg.header.stamp = ros::Time::now();
+  msg.rpms = convertRadSecToRPM(can_interface_->velocity_feedback_radsec.Get());
+  return msg;
 }
 
-void ThrusterControl::reportMotorTempSendTimeout(const ros::TimerEvent& timer)
+void ThrusterControl::SetMotorRPM(const thruster_control::SetRPM& message)
+{
+  double motor_radsec = convertRPMToRadSec(message.commanded_rpms);
+  can_interface_->velocity_radsec.Set(motor_radsec);
+  can_interface_->last_set_rpm_time.Set(ros::Time::now().toSec());
+}
+
+thruster_control::ReportMotorTemperature
+ThrusterControl::GetMotorTemperature()
 {
   thruster_control::ReportMotorTemperature message;
-
   message.header.stamp = ros::Time::now();
-  message.motor_temp = canIntf.motor_tempC.Get();
-  motorTemperatureCheck.test(message.motor_temp);
-
-  publisher_reportMotorTemp.publish(message);
-  diagnosticsUpdater.update();
+  message.motor_temp = can_interface_->motor_tempC.Get();
+  return message;
 }
 
-void ThrusterControl::reportBatteryHealthSendTimeout(const ros::TimerEvent& timer)
+sensor_msgs::BatteryState
+ThrusterControl::GetBatteryState()
 {
   sensor_msgs::BatteryState message;
 
   message.header.stamp = ros::Time::now();
-  message.voltage = canIntf.battery_voltage.Get()/1000.0;
-  //  message.temperature = canIntf.motor_tempC.Get();
-  message.current = canIntf.motor_current.Get()/-1000.0;
+  message.voltage = can_interface_->battery_voltage.Get() / 1000.0;
+  //  message.temperature = can_interface_->motor_tempC.Get();
+  message.current = can_interface_->motor_current.Get() / -1000.0;
   message.power_supply_status = 0;
   message.power_supply_health = 0;
   message.power_supply_technology = 0;
   message.present = 1;
   message.location = "A";
   message.serial_number = "1";
-  batteryCurrentCheck.test(message.voltage);
-  batteryVoltageCheck.test(message.current);
-  publisher_reportBatteryHealth.publish(message);
-  diagnosticsUpdater.update();
+
+  return message;
 }
-
-void ThrusterControl::handle_SetRPM(const thruster_control::SetRPM::ConstPtr& msg)
-{
-  double motor_radsec = convertRPMToRadSec(msg->commanded_rpms);
-  canIntf.velocity_radsec.Set(motor_radsec);
-  canIntf.last_set_rpm_time.Set(ros::Time::now().toSec());
-}
-
-double ThrusterControl::convertRPMToRadSec(double rpms) { return (rpms * RPM_TO_RADSEC); }
-
-double ThrusterControl::convertRadSecToRPM(double radsec) { return (radsec * RADSEC_TO_RPM); }
 
 }  // namespace robot
 }  // namespace qna

--- a/thruster_control/src/thruster_control_ros.cpp
+++ b/thruster_control/src/thruster_control_ros.cpp
@@ -1,0 +1,344 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+// Original version: Christopher Scianna Christopher.Scianna@us.QinetiQ.com
+
+/*
+ * thruster_control_ros.cpp
+ *
+ */
+
+#include "thruster_control/thruster_control_ros.h"
+
+#include <string>
+
+namespace qna
+{
+namespace robot
+{
+
+std::unique_ptr<CANIntf> ConfigureCANInterfaceUsingROSParams(ros::NodeHandle nh)
+{
+  std::unique_ptr<CANIntf> can_interface(new CANIntf());
+
+  double rpm_timeout = nh.param("set_rpm_timeout_seconds", 0.5);
+  ROS_DEBUG_STREAM("set_rpm_timeout_seconds set to  " << rpm_timeout);
+  can_interface->SetMotorTimeoutSeconds(rpm_timeout);
+
+  bool current_logging_enabled = nh.param("current_logging_enabled", false);
+  ROS_DEBUG_STREAM("current_logging_enabled set to  " <<
+                   current_logging_enabled ? "true" : "false");
+  can_interface->SetEnableCANLogging(current_logging_enabled);
+
+  // TODO(QNA) what should the default be??
+  std::string can_node_id = nh.param("can_node_id_1", std::string(""));
+  ROS_DEBUG_STREAM("CAN Node 1 Id =  " << can_node_id);
+  can_interface->AddCanNodeIdToList(can_node_id);
+
+  can_node_id = nh.param("can_node_id_2", std::string(""));
+  ROS_DEBUG_STREAM("CAN Node 2 Id =  " << can_node_id);
+  can_interface->AddCanNodeIdToList(can_node_id);
+
+  return std::move(can_interface);
+}
+
+ThrusterControlROS::ThrusterControlROS()
+  : ThrusterControlROS(ros::NodeHandle(), ros::NodeHandle("~"))
+{
+}
+
+ThrusterControlROS::ThrusterControlROS(std::unique_ptr<ThrusterControlInterface> thruster_control)
+  : ThrusterControlROS(ros::NodeHandle(), ros::NodeHandle("~"), std::move(thruster_control))
+{
+}
+
+ThrusterControlROS::ThrusterControlROS(const ros::NodeHandle& nh, const ros::NodeHandle& pnh)
+  : ThrusterControlROS(nh, pnh, std::unique_ptr<ThrusterControlInterface>(
+      new ThrusterControl(ConfigureCANInterfaceUsingROSParams(pnh))))
+{
+}
+
+ThrusterControlROS::ThrusterControlROS(const ros::NodeHandle& nh, const ros::NodeHandle& pnh,
+                                       std::unique_ptr<ThrusterControlInterface> thruster_control)
+  : nh_(nh), pnh_(pnh), thruster_control_(std::move(thruster_control))
+{
+  motor_rpm_subscriber_ =
+      nh_.subscribe("/thruster_control/set_rpm", 1, &ThrusterControlROS::OnMotorRPMSet, this);
+
+  motor_rpm_publisher_ =
+      diagnostic_tools::create_publisher<thruster_control::ReportRPM>(
+          nh_, "/thruster_control/report_rpm", 1);
+
+  motor_temperature_publisher_ =
+      diagnostic_tools::create_publisher<thruster_control::ReportMotorTemperature>(
+          nh_, "/thruster_control/report_motor_temperature", 1);
+
+  battery_health_publisher_ =
+      diagnostic_tools::create_publisher<sensor_msgs::BatteryState>(
+          nh_, "/thruster_control/report_battery_health", 1);
+
+  report_motor_rpm_period_ = pnh_.param("report_motor_rpm_period", 0.1);
+  report_motor_rpm_timer_ =
+      nh_.createTimer(ros::Duration(report_motor_rpm_period_),
+                      &ThrusterControlROS::OnReportMotorRPMTimeout, this);
+
+  report_motor_temperature_period_ = pnh_.param("report_motor_temperature_period", 0.5);
+  report_motor_temperature_timer_ =
+      nh_.createTimer(ros::Duration(report_motor_temperature_period_),
+                      &ThrusterControlROS::OnReportMotorTemperatureTimeout, this);
+
+  report_battery_health_period_ = pnh_.param("report_battery_health_period", 1.0);
+  report_battery_health_timer_ =
+      nh_.createTimer(ros::Duration(report_battery_health_period_),
+                      &ThrusterControlROS::OnReportBatteryHealthTimeout, this);
+}
+
+void ThrusterControlROS::MonitorMotorRPMUsing(diagnostic_updater::Updater* updater)
+{
+  if (!report_motor_rpm_rate_check_) {
+    diagnostic_tools::PeriodicMessageStatusParams params;
+    double min_report_motor_rpm_period =
+        pnh_.param("min_report_rpm_period", report_motor_rpm_period_ / 2.0);
+    params.min_acceptable_period(min_report_motor_rpm_period);
+    double max_report_motor_rpm_period =
+        pnh_.param("max_report_rpm_period", report_motor_rpm_period_ / 2.0);
+    params.max_acceptable_period(max_report_motor_rpm_period);
+    params.abnormal_diagnostic({
+        diagnostic_tools::Diagnostic::WARN,
+        health_monitor::ReportFault::THRUSTER_RPM_STALE});
+    using diagnostic_tools::PeriodicMessageStatus;
+    report_motor_rpm_rate_check_ = &(
+        motor_rpm_publisher_.add_check<PeriodicMessageStatus>("rate check", params));
+  }
+  updater->add(*report_motor_rpm_rate_check_);
+
+  if (!motor_rpm_check_) {
+    double max_allowed_motor_rpm = pnh_.param("max_allowed_rpm", 0.);
+    motor_rpm_check_ = diagnostic_tools::create_health_check<double>(
+        "Motor RPM check",
+        [max_allowed_motor_rpm](double rpms) -> diagnostic_tools::Diagnostic
+        {
+          if (std::abs(rpms) > max_allowed_motor_rpm)
+          {
+            return diagnostic_tools::Diagnostic(diagnostic_tools::Diagnostic::WARN)
+                .code(health_monitor::ReportFault::THRUSTER_RPM_THRESHOLD_REACHED)
+                .description("Absolute RPMs above threshold: |%f| > %f",
+                             rpms, max_allowed_motor_rpm);
+          }
+          return diagnostic_tools::Diagnostic::OK;
+        }
+    );
+  }
+  updater->add(motor_rpm_check_);
+}
+
+void ThrusterControlROS::MonitorMotorTemperatureUsing(diagnostic_updater::Updater* updater)
+{
+  if (!motor_temperature_rate_check_)
+  {
+    diagnostic_tools::PeriodicMessageStatusParams params;
+    double min_report_motor_temperature_period =
+        pnh_.param("min_report_motor_temperature_period",
+                    report_motor_temperature_period_ / 2.0);
+    params.min_acceptable_period(min_report_motor_temperature_period);
+    double max_report_motor_temperature_period =
+        pnh_.param("max_report_motor_temperature_period",
+                    report_motor_temperature_period_ * 2.0);
+    params.max_acceptable_period(max_report_motor_temperature_period);
+    params.abnormal_diagnostic({
+        diagnostic_tools::Diagnostic::WARN,
+        health_monitor::ReportFault::THRUSTER_TEMP_STALE});
+    using diagnostic_tools::PeriodicMessageStatus;
+    motor_temperature_rate_check_ = &(
+        motor_temperature_publisher_.add_check<PeriodicMessageStatus>("rate check", params));
+  }
+  updater->add(*motor_temperature_rate_check_);
+
+  if (!motor_temperature_stagnation_check_)
+  {
+    diagnostic_tools::MessageStagnationCheckParams params;
+    params.stagnation_diagnostic({
+        diagnostic_tools::Diagnostic::WARN,
+        health_monitor::ReportFault::THRUSTER_TEMP_STAGNATED});
+    double motor_temperature_steady_band = pnh_.param("motor_temperature_steady_band", 0.);
+    auto areTemperaturesEqual = [motor_temperature_steady_band](
+        const thruster_control::ReportMotorTemperature& a,
+        const thruster_control::ReportMotorTemperature& b)
+    {
+      return std::fabs(a.motor_temp - b.motor_temp < motor_temperature_steady_band);
+    };
+    using diagnostic_tools::MessageStagnationCheck;
+    motor_temperature_stagnation_check_ = &(
+        motor_temperature_publisher_.add_check<MessageStagnationCheck>(
+            "stagnation check", areTemperaturesEqual, params));
+  }
+  updater->add(*motor_temperature_stagnation_check_);
+
+  if (!motor_temperature_check_)
+  {
+    double motor_temperature_threshold = pnh_.param("motor_temperature_threshold", 50.);
+    motor_temperature_check_ = diagnostic_tools::create_health_check<double>(
+        "Motor temperature check",
+        [motor_temperature_threshold](double temperature) -> diagnostic_tools::Diagnostic
+        {
+          if (temperature > motor_temperature_threshold)
+          {
+            return diagnostic_tools::Diagnostic(diagnostic_tools::Diagnostic::ERROR)
+                .code(health_monitor::ReportFault::THRUSTER_TEMP_THRESHOLD_REACHED)
+                .description("Temperature above threshold: %f degC > %f degC",
+                             temperature, motor_temperature_threshold);
+          }
+          return diagnostic_tools::Diagnostic::OK;
+        }
+    );
+  }
+  updater->add(motor_temperature_check_);
+}
+
+void ThrusterControlROS::MonitorBatteryHealthUsing(diagnostic_updater::Updater* updater)
+{
+  if (!battery_health_rate_check_)
+  {
+    diagnostic_tools::PeriodicMessageStatusParams params;
+    double min_report_battery_health_period =
+        pnh_.param("min_report_battery_health_period", report_battery_health_period_ / 2.0);
+    params.min_acceptable_period(min_report_battery_health_period);
+    double max_report_battery_health_period =
+        pnh_.param("max_report_battery_health_period", report_battery_health_period_ * 2.0);
+    params.max_acceptable_period(max_report_battery_health_period);
+    params.abnormal_diagnostic({
+        diagnostic_tools::Diagnostic::WARN,
+        health_monitor::ReportFault::BATTERY_INFO_STALE});
+    using diagnostic_tools::PeriodicMessageStatus;
+    battery_health_rate_check_ =
+        &(battery_health_publisher_.add_check<PeriodicMessageStatus>("rate check", params));
+  }
+  updater->add(*battery_health_rate_check_);
+
+  if (!battery_health_stagnation_check_)
+  {
+    diagnostic_tools::MessageStagnationCheckParams params;
+    params.stagnation_diagnostic({
+        diagnostic_tools::Diagnostic::WARN,
+        health_monitor::ReportFault::BATTERY_INFO_STAGNATED});
+    double battery_current_steady_band = pnh_.param("battery_current_steady_band", 0.0);
+    double battery_voltage_steady_band = pnh_.param("battery_voltage_steady_band", 0.0);
+    auto areBatteryStatesEqual =
+        [battery_current_steady_band, battery_voltage_steady_band](
+            const sensor_msgs::BatteryState& a, const sensor_msgs::BatteryState& b)
+        {
+          return (std::fabs(a.current - b.current) < battery_current_steady_band) &&
+              (std::fabs(a.voltage - b.voltage) < battery_voltage_steady_band);
+        };
+    using diagnostic_tools::MessageStagnationCheck;
+    battery_health_stagnation_check_ = &(
+        battery_health_publisher_.add_check<MessageStagnationCheck>(
+            "stagnation check", areBatteryStatesEqual, params));
+  }
+  updater->add(*battery_health_stagnation_check_);
+
+  if (!battery_total_current_check_) {
+    double min_battery_total_current = pnh_.param("min_battery_total_current", 5000.0);
+    battery_total_current_check_ = diagnostic_tools::create_health_check<double>(
+        "Battery total current check",
+        [min_battery_total_current](double total_current) -> diagnostic_tools::Diagnostic
+        {
+          if (total_current < min_battery_total_current)
+          {
+            return diagnostic_tools::Diagnostic(diagnostic_tools::Diagnostic::WARN)
+                .code(health_monitor::ReportFault::BATTERY_CURRENT_THRESHOLD_REACHED)
+                .description("Battery total current - NOT OK (%f mA < %f mA)",
+                             total_current, min_battery_total_current);
+          }
+          return diagnostic_tools::Diagnostic::OK;
+        });
+  }
+  updater->add(battery_total_current_check_);
+
+  if (!battery_cell_voltage_check_)
+  {
+    double min_battery_cell_voltage = pnh_.param("min_battery_cell_voltage", 30.0);
+    battery_cell_voltage_check_ = diagnostic_tools::create_health_check<double>(
+        "Battery cell voltage check",
+        [min_battery_cell_voltage](double cell_voltage) -> diagnostic_tools::Diagnostic
+        {
+          if (cell_voltage < min_battery_cell_voltage)
+          {
+            return diagnostic_tools::Diagnostic(diagnostic_tools::Diagnostic::WARN)
+                .code(health_monitor::ReportFault::BATTERY_VOLTAGE_THRESHOLD_REACHED)
+                .description("Battery cell voltage - NOT OK (%f V < %f V)",
+                             cell_voltage, min_battery_cell_voltage);
+          }
+          return diagnostic_tools::Diagnostic::OK;
+        });
+  }
+  updater->add(battery_cell_voltage_check_);
+}
+
+void ThrusterControlROS::MonitorUsing(diagnostic_updater::Updater* updater)
+{
+  MonitorMotorRPMUsing(updater);
+  MonitorMotorTemperatureUsing(updater);
+  MonitorBatteryHealthUsing(updater);
+}
+
+void ThrusterControlROS::OnReportMotorRPMTimeout(const ros::TimerEvent&)
+{
+  thruster_control::ReportRPM message = thruster_control_->GetMotorRPM();
+  motor_rpm_check_.test(message.rpms);
+  motor_rpm_publisher_.publish(message);
+}
+
+void ThrusterControlROS::OnReportMotorTemperatureTimeout(const ros::TimerEvent&)
+{
+  thruster_control::ReportMotorTemperature message = thruster_control_->GetMotorTemperature();
+  motor_temperature_check_.test(message.motor_temp);
+  motor_temperature_publisher_.publish(message);
+}
+
+void ThrusterControlROS::OnReportBatteryHealthTimeout(const ros::TimerEvent&)
+{
+  sensor_msgs::BatteryState message = thruster_control_->GetBatteryState();
+  battery_total_current_check_.test(message.voltage);
+  battery_cell_voltage_check_.test(message.current);
+  battery_health_publisher_.publish(message);
+}
+
+void ThrusterControlROS::OnMotorRPMSet(const thruster_control::SetRPM::ConstPtr& message)
+{
+  thruster_control_->SetMotorRPM(*message);
+}
+
+}  // namespace robot
+}  // namespace qna

--- a/thruster_control/test/test_thruster_control_ros.cpp
+++ b/thruster_control/test/test_thruster_control_ros.cpp
@@ -1,0 +1,152 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * test_thruster_control_ros.cpp
+ *
+ */
+
+#include "thruster_control/thruster_control_ros.h"
+
+#include <memory>
+
+#include <gmock/gmock.h>
+
+#include <ros/ros.h>
+#include <ros/callback_queue.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+
+#include "thruster_control/thruster_control.h"
+
+
+namespace qna
+{
+namespace robot
+{
+namespace testing
+{
+
+class TestingUpdater : public diagnostic_updater::Updater
+{
+ public:
+  using diagnostic_updater::Updater::Updater;
+
+  using DiagnosticTaskInternal = diagnostic_updater::Updater::DiagnosticTaskInternal;
+
+  const std::vector<DiagnosticTaskInternal> &getTasks()
+  {
+    return diagnostic_updater::Updater::getTasks();
+  }
+};
+
+class MockThrusterControl : public ThrusterControlInterface
+{
+ public:
+  MOCK_METHOD0(GetMotorRPM, thruster_control::ReportRPM() override);
+  MOCK_METHOD1(SetMotorRPM, void(const thruster_control::SetRPM&) override);
+  MOCK_METHOD0(GetMotorTemperature, thruster_control::ReportMotorTemperature() override);
+  MOCK_METHOD0(GetBatteryState, sensor_msgs::BatteryState() override);
+};
+
+class ProxyThrusterControl : public ThrusterControlInterface
+{
+ public:
+  explicit ProxyThrusterControl(std::shared_ptr<ThrusterControlInterface> internal)
+    : internal_(internal) {}
+
+  thruster_control::ReportRPM GetMotorRPM() override { return internal_->GetMotorRPM(); }
+  void SetMotorRPM(const thruster_control::SetRPM& message) override { internal_->SetMotorRPM(message); };
+  thruster_control::ReportMotorTemperature GetMotorTemperature() override { return internal_->GetMotorTemperature(); }
+  sensor_msgs::BatteryState GetBatteryState() override { return internal_->GetBatteryState(); }
+ private:
+  std::shared_ptr<ThrusterControlInterface> internal_;
+};
+
+using ::testing::NiceMock;
+using ::testing::AtLeast;
+using ::testing::Return;
+
+TEST(TestThrusterControlROS, checks_motor_rpms)
+{
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
+  pnh.setParam("report_motor_rpm_period", 1.0);
+  pnh.setParam("max_allowed_motor_rpm", 100);
+  ros::Time::setNow(ros::Time());
+
+  std::shared_ptr<MockThrusterControl> mock(new MockThrusterControl());
+  std::unique_ptr<ThrusterControlInterface> proxy(new ProxyThrusterControl(mock));
+  ThrusterControlROS controller(nh, pnh, std::move(proxy));
+
+  TestingUpdater updater(nh, pnh);
+  controller.MonitorMotorRPMUsing(&updater);
+  EXPECT_GE(updater.getTasks().size(), 2);
+
+  thruster_control::ReportRPM rpm_message;
+  rpm_message.rpms = 200;
+  EXPECT_CALL(*mock, GetMotorRPM())
+    .Times(AtLeast(1))
+    .WillRepeatedly(Return(rpm_message));
+
+  thruster_control::ReportMotorTemperature temp_message;
+  temp_message.motor_temp = 10;
+  EXPECT_CALL(*mock, GetMotorTemperature())
+    .Times(AtLeast(1))
+    .WillRepeatedly(Return(temp_message));
+
+  sensor_msgs::BatteryState battery_message;
+  EXPECT_CALL(*mock, GetBatteryState())
+    .Times(AtLeast(1))
+    .WillRepeatedly(Return(battery_message));
+
+  ros::Time::setNow(ros::Time(1.5));
+  ros::CallbackQueue* queue = ros::getGlobalCallbackQueue();
+  queue->callAvailable(ros::WallDuration(1.0));
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "test_thruster_control_ros");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace testing
+}  // namespace robot
+}  // namespace qna
+
+int main(int argc, char ** argv)
+{
+  return qna::robot::testing::main(argc, argv);
+}

--- a/thruster_control/test/thruster_control_ros.test
+++ b/thruster_control/test/thruster_control_ros.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_thruster_control_ros" pkg="thruster_control" type="test_thruster_control_ros"/>
+</launch>


### PR DESCRIPTION
Precisely what the title says. This patch refactors the package to enable unit testing in a mostly ROS agnostic way. The latter is not quite true, but I think this patch is a reasonable tradeoff (w/o adding yet another layer of abstraction, between ROS and the rest).