### PR TITLE
Adding fin control code to map

### DIFF
--- a/health_monitor/include/health_monitor/health_monitor.h
+++ b/health_monitor/include/health_monitor/health_monitor.h
@@ -87,7 +87,8 @@ private:
         {"thruster_control_node", health_monitor::ReportFault::THRUSTER_NODE_DIED},
         {"autopilot_node", health_monitor::ReportFault::AUTOPILOT_NODE_DIED},
         {"battery_monitor_node", health_monitor::ReportFault::BATTERY_NODE_DIED},
-        {"jaus_ros_bridge", health_monitor::ReportFault::JAUS_NODE_DIED}
+        {"jaus_ros_bridge", health_monitor::ReportFault::JAUS_NODE_DIED},
+        {"fin_control", health_monitor::ReportFault::FIN_NODE_DIED}
         };
 
     void handle_ClearFault(const health_monitor::ClearFault::ConstPtr &msg);


### PR DESCRIPTION
# Description

The fin control code wasn't added to the map on the health monitor. This PR add the code to health monitor.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

- Using the hardware with rostest.
`rostest system_testbed test_system_fails_safely_if_fin_control_node_crashes.test `