### PR TITLE
Fix diagnostic_tools.PeriodicEventStatus implementation.

### DIFF
--- a/diagnostics_tools/src/diagnostic_tools/periodic_event_status.py
+++ b/diagnostics_tools/src/diagnostic_tools/periodic_event_status.py
@@ -124,22 +124,22 @@ class PeriodicEventStatus(PeriodicDiagnosticTask):
     def run(self, stat):
         with self._lock:
             diagnostic = self._config.diagnostics.normal
-            if rospy.Time.now() - self._last_time > self._config.max_reasonable_period:
+            if (rospy.Time.now() - self._last_time).to_sec() > self._config.max_reasonable_period:
                 # Unreasonable time delta, event is likely stale.
                 self._short_term_period.reset()
             if self._short_term_period.sample_count > 0:
-                if self._last_cycle_period.average < self._config.min_acceptable_period or \
-                   self._last_cycle_period.average > self._config.max_acceptable_period:
+                if self._short_term_period.average < self._config.min_acceptable_period or \
+                   self._short_term_period.average > self._config.max_acceptable_period:
                     diagnostic = self._config.diagnostics.abnormal
                 stat.summary(diagnostic.status, diagnostic.description)
                 if diagnostic.code is not None:
                     stat.add('Code', diagnostic.code)
                 stat.add(
-                    'Average period (last cycle)', self._last_cycle_period.average)
+                    'Average period (short term)', self._short_term_period.average)
                 stat.add(
-                    'Minimum period (last cycle)', self._last_cycle_period.minimum)
+                    'Minimum period (short term)', self._short_term_period.minimum)
                 stat.add(
-                    'Maximum period (last cycle)', self._last_cycle_period.maximum)
+                    'Maximum period (short term)', self._short_term_period.maximum)
             else:
                 diagnostic = self._config.diagnostics.stale
                 stat.summary(diagnostic.status, diagnostic.description)


### PR DESCRIPTION
# Description

Some regressions were introduced to `diagnostic_tools` Python API implementation along with #60. This patch amends it.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Start pressure sensor driver on the vehicle:

```sh
roslaunch system_bringup pressure_sensor.launch
```

Check it is functional.