### PR TITLE
Use u64 formats for diagnostic codes.

### DIFF
--- a/diagnostics_tools/include/diagnostic_tools/health_check.h
+++ b/diagnostics_tools/include/diagnostic_tools/health_check.h
@@ -39,6 +39,7 @@
 #ifndef DIAGNOSTIC_TOOLS_HEALTH_CHECK_H
 #define DIAGNOSTIC_TOOLS_HEALTH_CHECK_H
 
+#include <cinttypes>
 #include <map>
 #include <mutex>  // NOLINT(build/c++11)
 #include <string>
@@ -106,7 +107,7 @@ private:
       stat.summary(diagnostic_.status(), diagnostic_.description());
       if (diagnostic_.has_code())
       {
-        stat.add("Code", diagnostic_.code());
+        stat.addf("Code", "%" PRIu64, diagnostic_.code());
       }
       for (const auto &kv : diagnostic_.data())
       {

--- a/diagnostics_tools/include/diagnostic_tools/message_stagnation_check.h
+++ b/diagnostics_tools/include/diagnostic_tools/message_stagnation_check.h
@@ -39,6 +39,7 @@
 #ifndef DIAGNOSTIC_TOOLS_MESSAGE_STAGNATION_CHECK_H
 #define DIAGNOSTIC_TOOLS_MESSAGE_STAGNATION_CHECK_H
 
+#include <cinttypes>
 #include <deque>
 #include <mutex>  // NOLINT(build/c++11)
 #include <string>
@@ -165,7 +166,7 @@ public:
     stat.summary(diagnostic.status(), diagnostic.description());
     if (diagnostic.has_code())
     {
-      stat.add("Code", diagnostic.code());
+      stat.addf("Code", "%" PRIu64, diagnostic.code());
     }
   }
 

--- a/diagnostics_tools/src/periodic_event_status.cpp
+++ b/diagnostics_tools/src/periodic_event_status.cpp
@@ -34,6 +34,7 @@
 
 #include "diagnostic_tools/periodic_event_status.h"
 
+#include <cinttypes>
 #include <string>
 
 #include <diagnostic_msgs/DiagnosticStatus.h>
@@ -101,7 +102,7 @@ void PeriodicEventStatus::run(diagnostic_updater::DiagnosticStatusWrapper& stat)
                    params_.abnormal_diagnostic().description());
       if (params_.abnormal_diagnostic().has_code())
       {
-        stat.addf("Code", "%u", params_.abnormal_diagnostic().code());
+        stat.addf("Code", "%" PRIu64, params_.abnormal_diagnostic().code());
       }
     }
     else
@@ -110,7 +111,7 @@ void PeriodicEventStatus::run(diagnostic_updater::DiagnosticStatusWrapper& stat)
                    params_.normal_diagnostic().description());
       if (params_.normal_diagnostic().has_code())
       {
-        stat.addf("Code", "%u", params_.normal_diagnostic().code());
+        stat.addf("Code", "%" PRIu64, params_.normal_diagnostic().code());
       }
     }
     stat.addf("Average period (short term)", "%f", short_term_period_.average());
@@ -123,7 +124,7 @@ void PeriodicEventStatus::run(diagnostic_updater::DiagnosticStatusWrapper& stat)
                  params_.stale_diagnostic().description());
     if (params_.stale_diagnostic().has_code())
     {
-      stat.addf("Code", "%f", params_.stale_diagnostic().code());
+      stat.addf("Code", "%" PRIu64, params_.stale_diagnostic().code());
     }
   }
   if (long_term_period_.sample_count() > 0)


### PR DESCRIPTION
# Description

Codes in `diagnostic_tools` are 64 bits unsigned integers but the formats being used for stringification may not be. This patch ensures these are always treated as 64 bits unsigned integers in all platforms.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Run a `system_testbed` test for diagnostics against a master you can introspect

*In one terminal*
```sh
roscore
```

*In another terminal*
```sh
rostest -r -t system_testbed test_system_fails_safely_if_battery_report_rate_is_out_of_limits.test 
```

Monitor the `/diagnostics` topic and ensure published codes are consistent with those listed in the health_monitor/ReporFault message. 