### PR TITLE
Repurpose battery total current check to enforce maximums.

### DIFF
--- a/thruster_control/include/thruster_control/thruster_control.h
+++ b/thruster_control/include/thruster_control/thruster_control.h
@@ -93,7 +93,7 @@ class ThrusterControl
   bool currentLoggingEnabled;
   double motorTemperatureThreshold;
   double maxAllowedMotorRPM;
-  double minBatteryTotalCurrent;
+  double maxBatteryTotalCurrent;
 
   void handle_SetRPM(const thruster_control::SetRPM::ConstPtr& msg);
 

--- a/thruster_control/launch/thruster_control.launch
+++ b/thruster_control/launch/thruster_control.launch
@@ -15,7 +15,7 @@
   <arg name="reportBatteryHealthRate" default="1.0"/>
   <arg name="minReportBatteryHealthRate" default="0.5"/>
   <arg name="maxReportBatteryHealthRate" default="2.0"/>
-  <arg name="minBatteryTotalCurrent" default="1"/>
+  <arg name="maxBatteryTotalCurrent" default="1"/>
   <arg name="minBatteryCellVoltage" default="1"/>
   <arg name="batteryTotalCurrentSteadyBand" default="0.0"/>
 
@@ -37,7 +37,7 @@
     <param name="battery_total_current_steady_band" type="double" value="$(arg batteryTotalCurrentSteadyBand)"/>
     <param name="min_report_battery_health_rate" type="double" value="$(arg minReportBatteryHealthRate)" />
     <param name="max_report_battery_health_rate" type="double" value="$(arg maxReportBatteryHealthRate)" />
-    <param name="min_battery_total_current" type="double" value="$(arg minBatteryTotalCurrent)"/>
+    <param name="max_battery_total_current" type="double" value="$(arg maxBatteryTotalCurrent)"/>
     <param name="min_battery_cell_voltage" type="double" value="$(arg minBatteryCellVoltage)"/>
   </node>
 


### PR DESCRIPTION
# Description

A minimum battery current check is no longer meaningful (as it only monitors the thruster motor current consumption now). Instead of removing the check entirely, this patch repurposes the check to look for battery current maximums. 

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

A. Bringup the full system and ensure not battery faults are generated under normal operating conditions.
B. Run `system_testbed` battery current threshold test and make sure it passes:

```sh
rostest system_testbed test_system_fails_safely_if_battery_current_threshold_is_reached.test
```
