### PR TITLE
Ensure pressure sensor shuts down if rospy shuts down

### DIFF
--- a/keller_9lx_pressure/scripts/keller_9lx_pressure_main
+++ b/keller_9lx_pressure/scripts/keller_9lx_pressure_main
@@ -253,7 +253,7 @@ class Keller9lxPressureSensorDriverNode(object):
         """
         reconnection_attempts = 0
         time_of_last_reconnection = None
-        while True:
+        while not rospy.is_shutdown():
             try:
                 port = serial.Serial(
                     port=self.__sensor_port,


### PR DESCRIPTION
# Description

Precisely what the title says. Without this patch, the pressure sensor node won't terminate on SIGINT.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

- Launch pressure_sensor.launch in `system_bringup` package.
```sh
roslaunch system_bringup pressure_sensor.launch
``` 
- Kill it with Ctrl+C.

Pressure sensor should terminate gracefully.