### PR TITLE
Use timer for fin_control angle reporting.

### DIFF
--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -78,23 +78,19 @@ class FinControl
  public:
   explicit FinControl(ros::NodeHandle& nodeHandle);
   virtual ~FinControl();
-  ros::Timer reportAngleTimer;
-  void reportAngleSendTimeout(const ros::TimerEvent& timer);
-  void reportAngles();
 
  private:
-  boost::shared_ptr<boost::thread> m_thread;
-
   bool fincontrolEnabled;
   bool servosON;
   bool reportAnglesEnabled;
   bool currentLoggingEnabled;
 
-  void workerFunc();
-  void Start();
-  void Stop();
+  void reportAngles();
+
   float radiansToDegrees(float radians);
   float degreesToRadians(float degrees);
+
+  void reportAngleSendTimeout(const ros::TimerEvent& ev);
   void handleSetAngle(const fin_control::SetAngle::ConstPtr& msg);
   void handleSetAngles(const fin_control::SetAngles::ConstPtr& msg);
   void handleEnableReportAngles(const fin_control::EnableReportAngles::ConstPtr& msg);
@@ -112,6 +108,7 @@ class FinControl
   ros::Subscriber subscriber_setAngles;
   ros::Subscriber subscriber_enableReportAngles;
   ros::Publisher publisher_reportAngle;
+  ros::Timer timer_reportAngle;
 
   DynamixelWorkbench myWorkBench;
 


### PR DESCRIPTION
# Description

By pushing angle reporting to a separate thread *without* locking SDK API access, it contends for the hardware with angle update subscribers. This patch uses a timer instead of a thread, and thus all callbacks are mutually exclusive by virtue of ROS single threaded executor.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

- Launch `fin_control.launch` in `system_bringup` package.
```sh
roslaunch system_bringup fin_control.launch
```
- Publish a fixed message to `/fin_control/set_angles` using `rostopic pub`.

Node should not log any read/write errors.