### PR TITLE
Drop fin angle reporting enable interface

### DIFF
--- a/autopilot/include/autopilot/autopilot.h
+++ b/autopilot/include/autopilot/autopilot.h
@@ -55,7 +55,6 @@
 #include <sstream>
 
 #include "autopilot/pid.h"
-#include "fin_control/EnableReportAngles.h"
 #include "fin_control/ReportAngle.h"
 #include "fin_control/SetAngles.h"
 #include "jaus_ros_bridge/ActivateManualControl.h"
@@ -83,7 +82,6 @@ class AutoPilotNode
   ros::Publisher autoPilotInControlPub;
   ros::Publisher thrusterPub;
   ros::Publisher finsControlPub;
-  ros::Publisher finsEnableReportingPub;
 
   ros::Subscriber jausRosSub;
 

--- a/fin_control/CMakeLists.txt
+++ b/fin_control/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 add_message_files(
    FILES
-   EnableReportAngles.msg
    ReportAngle.msg
    SetAngle.msg
    SetAngles.msg

--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -58,7 +58,6 @@
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_tools/message_stagnation_check.h>
 #include <diagnostic_tools/periodic_message_status.h>
-#include <fin_control/EnableReportAngles.h>
 #include <fin_control/ReportAngle.h>
 #include <fin_control/SetAngle.h>
 #include <fin_control/SetAngles.h>
@@ -82,7 +81,6 @@ class FinControl
  private:
   bool fincontrolEnabled;
   bool servosON;
-  bool reportAnglesEnabled;
   bool currentLoggingEnabled;
 
   void reportAngles();
@@ -93,7 +91,6 @@ class FinControl
   void reportAngleSendTimeout(const ros::TimerEvent& ev);
   void handleSetAngle(const fin_control::SetAngle::ConstPtr& msg);
   void handleSetAngles(const fin_control::SetAngles::ConstPtr& msg);
-  void handleEnableReportAngles(const fin_control::EnableReportAngles::ConstPtr& msg);
 
   double maxCtrlFinAngle;
   double ctrlFinOffset;

--- a/fin_control/msg/EnableReportAngles.msg
+++ b/fin_control/msg/EnableReportAngles.msg
@@ -1,2 +1,0 @@
-bool enable_report_angles
-

--- a/fin_control/src/fin_control.cpp
+++ b/fin_control/src/fin_control.cpp
@@ -52,8 +52,6 @@ FinControl::FinControl(ros::NodeHandle &nodeHandle)
 {
   diagnosticsUpdater.setHardwareID("fin_control");
 
-  reportAnglesEnabled = true;
-
   fincontrolEnabled = false;
   std::string serial_dev = "/dev/ttyUSB0";
   int serial_baud = 57600;
@@ -101,8 +99,6 @@ FinControl::FinControl(ros::NodeHandle &nodeHandle)
       nodeHandle.subscribe("/fin_control/set_angle", 10, &FinControl::handleSetAngle, this);
   subscriber_setAngles =
       nodeHandle.subscribe("/fin_control/set_angles", 10, &FinControl::handleSetAngles, this);
-  subscriber_enableReportAngles = nodeHandle.subscribe(
-      "/fin_control/enable_report_angles", 10, &FinControl::handleEnableReportAngles, this);
 
   publisher_reportAngle =
       nodeHandle.advertise<fin_control::ReportAngle>("/fin_control/report_angle", 1);
@@ -198,8 +194,6 @@ void FinControl::reportAngles()
   float radianAngleFromMyWorkBench = 0.;
 
   message.header.stamp = ros::Time::now();
-
-  if (!reportAnglesEnabled) return;  // do not interfere with fins updating
 
   for (int id = 1; id <= numOfIDs; ++id)
   {
@@ -356,18 +350,6 @@ void FinControl::handleSetAngle(const fin_control::SetAngle::ConstPtr &msg)
   const char *log;
   if (!(myWorkBench.goalPosition(msg->ID, angle_plus_offet, &log)))
     ROS_ERROR("Could not set servo angle for ID %d %s", msg->ID, log);
-}
-
-void FinControl::handleEnableReportAngles(const fin_control::EnableReportAngles::ConstPtr &msg)
-{
-  if (msg->enable_report_angles)
-  {
-    reportAnglesEnabled = true;
-  }
-  else
-  {
-    reportAnglesEnabled = false;
-  }
 }
 
 void FinControl::reportAngleSendTimeout(const ros::TimerEvent& ev)


### PR DESCRIPTION
# Description

This patch removes `fin_control` node's `/enable_reporting_angles` interface entirely, along with its use cases in the `autopilot` node.

Follow-up after #73.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Run `system_testbed` package tests:

```sh
catkin_make run_tests_system_testbed
```

All behavior tests should be passing.

