### PR TITLE
Make sure autopilot abides to thruster RPM limits

### DIFF
--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -416,10 +416,10 @@ void AutoPilotNode::workerFunc()
           fabs(desiredSpeed) >= minimalSpeed)
         setRPM.commanded_rpms =
             (fabs(setRPM.commanded_rpms) / setRPM.commanded_rpms) * rpmPerKnot * minimalSpeed;
-      else if (fabs(setRPM.commanded_rpms) > thruster_control::SetRPM::MAX_RPM)
+      if (fabs(setRPM.commanded_rpms) > thruster_control::SetRPM::MAX_RPM)
         setRPM.commanded_rpms = (fabs(setRPM.commanded_rpms) / setRPM.commanded_rpms) *
                                 thruster_control::SetRPM::MAX_RPM;
-      else if (fabs(setRPM.commanded_rpms) > maxAllowedThrusterRpm)
+      if (fabs(setRPM.commanded_rpms) > maxAllowedThrusterRpm)
         setRPM.commanded_rpms =
             (fabs(setRPM.commanded_rpms) / setRPM.commanded_rpms) * maxAllowedThrusterRpm;
       if (setRPM.commanded_rpms < 0.0 &&


### PR DESCRIPTION
# Description

Without this patch, if commanded RPMs are above `thruster_control/SetRPM` hard-coded limit, a lower configured limit would not be applied.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Use a speed setpoint (in knots) that would result in the hard-coded RPM limit to be surpassed (i.e. above 5000 RPMs).