### PR TITLE
Add missing jaus_ros_bridge dependencies.

### DIFF
--- a/jaus_ros_bridge/CMakeLists.txt
+++ b/jaus_ros_bridge/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
   mission_manager
   thruster_control
   health_monitor
+  fin_control
 )
 
 #find_package(catkin REQUIRED COMPONENTS
@@ -128,7 +129,7 @@ catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES jaus_ros_bridge
 #  LIBRARIES fin_control
-  CATKIN_DEPENDS roscpp rospy sensor_msgs std_msgs health_monitor
+  CATKIN_DEPENDS roscpp rospy sensor_msgs std_msgs health_monitor fin_control
 #  DEPENDS system_lib
 )
 

--- a/jaus_ros_bridge/CMakeLists.txt
+++ b/jaus_ros_bridge/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   mission_manager
   thruster_control
+  health_monitor
 )
 
 #find_package(catkin REQUIRED COMPONENTS
@@ -127,7 +128,7 @@ catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES jaus_ros_bridge
 #  LIBRARIES fin_control
-  CATKIN_DEPENDS roscpp rospy sensor_msgs std_msgs 
+  CATKIN_DEPENDS roscpp rospy sensor_msgs std_msgs health_monitor
 #  DEPENDS system_lib
 )
 

--- a/jaus_ros_bridge/package.xml
+++ b/jaus_ros_bridge/package.xml
@@ -61,6 +61,7 @@
   <build_depend>pose_estimator</build_depend>
   <build_depend>mission_manager</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>health_monitor</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
@@ -69,6 +70,7 @@
   <build_export_depend>thruster_control</build_export_depend>
   <build_export_depend>mission_manager</build_export_depend>
   <build_export_depend>pose_estimator</build_export_depend>
+  <build_export_depend>health_monitor</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
@@ -78,7 +80,7 @@
   <exec_depend>pose_estimator</exec_depend>
   <exec_depend>mission_manager</exec_depend>
   <exec_depend>message_runtime</exec_depend>
-
+  <exec_depend>health_monitor</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
# Description

Precisely what the title says. `jaus_ros_bridge` package was not fully declaring a dependency against the `health_monitor` and `fin_control` packages.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

1. Check `catkin_make` (still) builds successfully
2. Check `catkin_make_isolated` or cross-compilation builds successfully.