### PR TITLE
Add mission_manager as an autopilot dependency.

### DIFF
--- a/autopilot/CMakeLists.txt
+++ b/autopilot/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   thruster_control
   jaus_ros_bridge
   message_generation
+  mission_manager
 )
 
 add_message_files(
@@ -34,7 +35,7 @@ generate_messages(
 
 catkin_package(
  INCLUDE_DIRS include
- CATKIN_DEPENDS fin_control pose_estimator roscpp rospy std_msgs thruster_control jaus_ros_bridge
+ CATKIN_DEPENDS fin_control pose_estimator roscpp rospy std_msgs thruster_control jaus_ros_bridge mission_manager
 )
 
 roslint_cpp(


### PR DESCRIPTION
# Description

Precisely what the title says. `autopilot` package was not fully declaring a dependency against the `mission_manager` package.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

1. Check `catkin_make` (still) builds successfully
2. Check `catkin_make_isolated` or cross-compilation builds successfully.