### PR TITLE
Fix bad ros::NodeHandle::param() use in vectornav package

### DIFF
--- a/vectornav/src/main.cpp
+++ b/vectornav/src/main.cpp
@@ -349,11 +349,10 @@ int run(int argc, char *argv[])
     pn.param<int>("serial_baud", SensorBaudrate, 115200);
     pn.param<int>("fixed_imu_rate", SensorImuRate, 800);
     
-    min_async_output_rate = static_cast<double>(async_output_rate) / 2;
-    max_async_output_rate = static_cast<double>(async_output_rate) * 2;
-
-    pn.param<double>("min_async_output_rate", min_async_output_rate);
-    pn.param<double>("max_async_output_rate", max_async_output_rate);
+    pn.param<double>("min_async_output_rate", min_async_output_rate,
+                     static_cast<double>(async_output_rate) / 2);
+    pn.param<double>("max_async_output_rate", max_async_output_rate,
+                     static_cast<double>(async_output_rate) * 2);
     pn.param<double>("orientation_steady_band", orientationSteadyBand);
     diagnostic_updater::Updater diagnosticsUpdater;
     diagnosticsUpdater.setHardwareID("imu");


### PR DESCRIPTION
# Description

Precisely what the title says. We did not notice in the past because defaults were matching configured values.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Launch `vectornav` IMU driver node with a low output rate:

```sh
roslaunch system_bringup vectornav.launch async_output_rate:=5
```

Check the `/diagnostics` topic. Rate checks should've triggered.