### PR TITLE
Drop health_monitor faults' mutex

### DIFF
--- a/health_monitor/include/health_monitor/health_monitor.h
+++ b/health_monitor/include/health_monitor/health_monitor.h
@@ -75,7 +75,6 @@ public:
     void setFault(uint64_t fault_id);
 
 private:
-    std::mutex faultArrayMutex;
     uint64_t faults;
     std::unordered_map<std::string, uint64_t> uErrorMap
         {

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -88,15 +88,11 @@ void HealthMonitor::handle_ClearFault(const health_monitor::ClearFault::ConstPtr
 {
     if (msg->fault_id == health_monitor::ClearFault::ALL_FAULTS)
     {
-        faultArrayMutex.lock();
         faults = 0;
-        faultArrayMutex.unlock();
     }
     else
     {
-        faultArrayMutex.lock();
         faults &= ~msg->fault_id;
-        faultArrayMutex.unlock();
     }
 }
 
@@ -145,22 +141,16 @@ void HealthMonitor::handle_rosmonFaults(const rosmon_msgs::State &msg)
 
 void HealthMonitor::setFault(uint64_t fault_id)
 {
-    faultArrayMutex.lock();
     faults |= fault_id;
-    faultArrayMutex.unlock();
 }
 
 void HealthMonitor::sendFaults()
 {
     health_monitor::ReportFault message;
 
-    faultArrayMutex.lock();
-    uint64_t tempFaultID = faults;
-    faultArrayMutex.unlock();
-
     ROS_DEBUG_STREAM("Error Code: " << faults);
     message.header.stamp = ros::Time::now();
-    message.fault_id = tempFaultID;
+    message.fault_id = faults;
 
     publisher_reportFault.publish(message);
     diagnosticsUpdater.update();


### PR DESCRIPTION
# Description

There's no need for a mutex in `health_monitor`'s implementation as it spins in a single thread (i.e. the main thread).

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing
