### PR TITLE
Disable thruster_control current logging by default

### DIFF
--- a/thruster_control/launch/thruster_control.launch
+++ b/thruster_control/launch/thruster_control.launch
@@ -12,6 +12,7 @@
   <arg name="canNodeId2" default="0x08"/>
   <arg name="motorTemperatureThreshold" default="50.0"/>
   <arg name="maxAllowedMotorRPM" default="0.0"/>
+  <arg name="currentLoggingEnabled" default="false"/>
   <arg name="reportBatteryHealthRate" default="1.0"/>
   <arg name="minReportBatteryHealthRate" default="0.5"/>
   <arg name="maxReportBatteryHealthRate" default="2.0"/>
@@ -28,7 +29,7 @@
     <param name="max_report_motor_temperature_rate" type="double" value="$(arg maxTempRate)" />
     <param name="motor_temperature_steady_band" type="double" value="$(arg motorTemperatureSteadyBand)"/>
     <param name="set_rpm_timeout_seconds" type="double" value="$(arg setRPMTimeout)" />
-  	<param name="current_logging_enabled" type="boolean" value="true" />
+    <param name="current_logging_enabled" type="boolean" value="$(arg currentLoggingEnabled)" />
     <param name="can_node_id_1" type="string" value="$(arg canNodeId1)" />
     <param name="can_node_id_2" type="string" value="$(arg canNodeId2)" />
     <param name="motor_temperature_threshold" type="double" value="$(arg motorTemperatureThreshold)" />


### PR DESCRIPTION
# Description

This patch reduces the verbosity of `thruster_control`, while still allowing a user to bump it up again.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing