### PR TITLE
Disable fin_control current logging by default

### DIFF
--- a/fin_control/launch/fin_control.launch
+++ b/fin_control/launch/fin_control.launch
@@ -5,13 +5,15 @@
   <arg name="reportAngleRate" default="0.04"/>
   <arg name="minReportAngleRate" default="0.02"/>
   <arg name="maxReportAngleRate" default="0.08"/>
+  <arg name="currentLoggingEnabled" default="false"/>
+
   <node pkg="fin_control" type="fin_control_node" name="fin_control" output="screen">
     <param name="port" type="string" value="$(arg portName)" />
     <param name="baud" type="int" value="$(arg baudRate)" />
     <param name="max_ctrl_fin_angle" type="double" value="$(arg maxCtrlFinAngle)" />
     <param name="ctrl_fin_offset" type="double" value="90.0" />
     <param name="ctrl_fin_scale_factor" type="double" value="-1.0" />
-    <param name="current_logging_enabled" type="boolean" value="true" />
+    <param name="current_logging_enabled" type="boolean" value="$(arg currentLoggingEnabled)" />
     <param name="report_angle_rate" type="double" value="$(arg reportAngleRate)" />
     <param name="min_report_angle_rate" type="double" value="$(arg minReportAngleRate)" />
     <param name="max_report_angle_rate" type="double" value="$(arg maxReportAngleRate)" />


### PR DESCRIPTION
# Description

This patch reduces `fin_control` verbosity, while still allowing a user to bump it up if need be.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing
