### PR TITLE
Cap thruster RPMs in thruster_control node

### DIFF
--- a/autopilot/include/autopilot/autopilot.h
+++ b/autopilot/include/autopilot/autopilot.h
@@ -152,7 +152,6 @@ class AutoPilotNode
   double desiredRudder;
   double desiredSpeed;
 
-  double maxAllowedThrusterRpm;
   double minimalSpeed;       // knots
   double rpmPerKnot;
   int controlLoopRate;       // Hz

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -106,8 +106,6 @@ AutoPilotNode::AutoPilotNode(ros::NodeHandle& node_handle) : nh(node_handle)
                  allowReverseThrusterAutopilot, false);
   nh.param<bool>("/autopilot_node/thruster_enabled", thrusterEnabled, false);
 
-  nh.param<double>("/thruster_control_node/max_allowed_motor_rpm", maxAllowedThrusterRpm, 0);
-
   jausRosSub = nh.subscribe("/jaus_ros_bridge/activate_manual_control", 1,
                               &AutoPilotNode::HandleActivateManualControl, this);
   correctedDataSub =
@@ -406,12 +404,6 @@ void AutoPilotNode::workerFunc()
           fabs(desiredSpeed) >= minimalSpeed)
         setRPM.commanded_rpms =
             (fabs(setRPM.commanded_rpms) / setRPM.commanded_rpms) * rpmPerKnot * minimalSpeed;
-      if (fabs(setRPM.commanded_rpms) > thruster_control::SetRPM::MAX_RPM)
-        setRPM.commanded_rpms = (fabs(setRPM.commanded_rpms) / setRPM.commanded_rpms) *
-                                thruster_control::SetRPM::MAX_RPM;
-      if (fabs(setRPM.commanded_rpms) > maxAllowedThrusterRpm)
-        setRPM.commanded_rpms =
-            (fabs(setRPM.commanded_rpms) / setRPM.commanded_rpms) * maxAllowedThrusterRpm;
       if (setRPM.commanded_rpms < 0.0 &&
           !allowReverseThrusterAutopilot)  // don't have thruster move in reverse.
         setRPM.commanded_rpms = 0.0;


### PR DESCRIPTION
# Description

This patch moves `autopilot` node code that checks and enforces thruster motor RPM limits to the `thruster_control` node. This way, these will always be honored (during missions, during teleoperation).

Follow-up after #75.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing (no new tests are failing)

# How To Test

## Test A

1. Launch `thruster_control` node in isolation:

```sh
 roslaunch system_bringup thruster_control.launch
```

2. Set motor RPMs beyond the configured limit using `rostopic pub`

The node should cap them.