### PR TITLE
Drop motor command timeout logs in thruster's CAN interface

### DIFF
--- a/thruster_control/src/CANIntf.cpp
+++ b/thruster_control/src/CANIntf.cpp
@@ -317,7 +317,6 @@ void CANIntf::SetVehicleCommandData()
 	if ((now-last_time_secs) > GetMotorTiemoutSeconds())
 	{
 		vel = 0.0;
-		ROS_INFO("now[%lf] - lastTime[%lf] = %lf. MotorTimeout[%lf] in seconds", now, last_time_secs, now-last_time_secs, GetMotorTiemoutSeconds());	
 	}
 
     // setting info to CAN bus


### PR DESCRIPTION
# Description

Precisely what the title says. This log creates unnecessary noise and it adds little to no information.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Launch `thruster_control` node only:

```sh
roslaunch system_bringup thruster_control.launch
```

No motor command timeouts should be observed.