### PR TITLE
Make diagnostic_tools' periodic event checks robust to initialization delays

### DIFF
--- a/diagnostics_tools/include/diagnostic_tools/periodic_event_status.h
+++ b/diagnostics_tools/include/diagnostic_tools/periodic_event_status.h
@@ -192,6 +192,7 @@ private:
   PeriodicEventStatusParams params_;
   SampledStatistics<double> short_term_period_;
   SampledStatistics<double> long_term_period_;
+  ros::Time start_stamp_;
   ros::Time last_stamp_;
   std::mutex mutex_;
 };

--- a/diagnostics_tools/src/diagnostic_tools/periodic_event_status.py
+++ b/diagnostics_tools/src/diagnostic_tools/periodic_event_status.py
@@ -108,7 +108,7 @@ class PeriodicEventStatus(PeriodicDiagnosticTask):
             if not self._last_time.is_zero():
                 if self._last_time <= time:
                     time_delta = (time - self._last_time).to_sec()
-                    if delta_in_seconds <= self._config.max_reasonable_period:
+                    if time_delta <= self._config.max_reasonable_period:
                         self._short_term_period.update(time_delta)
                         self._long_term_period.update(time_delta)
                     else:


### PR DESCRIPTION

# Description

This patch allows events to delay up to a maximum reasonable period after construction. Hopefully, this will eliminate spurious faults on system bring-up.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Power cycle the vehicle. On bring up, no staling faults should be reported.