### PR TITLE
Change behavior node type

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -117,6 +117,7 @@ find_package(rostest REQUIRED)
 add_rostest(test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test)
 add_rostest(test/test_jaus_ros_bridge_interface_mission_control.test)
 add_rostest(test/test_mission_control_publishes_heartbeat.test)
+add_rostest(test/test_mission_control_behaviors.test)
 
 catkin_add_gtest(behavior-object-test test/test_behavior_object.cpp)
 target_link_libraries(behavior-object-test ${catkin_LIBRARIES} ${MISSION_CONTROL_LIB})

--- a/mission_control/include/mission_control/behavior.h
+++ b/mission_control/include/mission_control/behavior.h
@@ -64,12 +64,6 @@ class Behavior : public BT::ActionNodeBase
       case BT::NodeStatus::RUNNING:
         setStatus(behaviorRunningProcess());
         break;
-      case BT::NodeStatus::SUCCESS:
-        setStatus(BT::NodeStatus::SUCCESS);
-        break;
-      case BT::NodeStatus::FAILURE:
-        setStatus(BT::NodeStatus::FAILURE);
-        break;
       default:
         throw std::logic_error("Unexpected state in ::tick()");
         break;

--- a/mission_control/include/mission_control/behavior.h
+++ b/mission_control/include/mission_control/behavior.h
@@ -76,7 +76,7 @@ class Behavior : public BT::ActionNodeBase
     }
     return status();
   }
-  virtual void halt() override { setStatus(BT::NodeStatus::IDLE); }
+  void halt() override { setStatus(BT::NodeStatus::IDLE); }
 
   /// Method (to be implemented by the user) to implement the function when the satus is RUNNING
   /// User should return the NodeStatus of the action (RUNNING, SUCCESS or FAILURE).

--- a/mission_control/include/mission_control/behavior.h
+++ b/mission_control/include/mission_control/behavior.h
@@ -43,13 +43,12 @@
 
 namespace mission_control
 {
-class Behavior : public BT::AsyncActionNode
+class Behavior : public BT::ActionNodeBase
 {
  public:
   Behavior(const std::string& name, const BT::NodeConfiguration& config)
-      : AsyncActionNode(name, config)
+      : BT::ActionNodeBase(name, config)
   {
-    idleToRunning = true;
   }
 
   ~Behavior() {}
@@ -66,7 +65,7 @@ class Behavior : public BT::AsyncActionNode
         setStatus(behaviorRunningProcess());
         break;
       case BT::NodeStatus::SUCCESS:
-        halt();
+        setStatus(BT::NodeStatus::SUCCESS);
         break;
       case BT::NodeStatus::FAILURE:
         setStatus(BT::NodeStatus::FAILURE);
@@ -78,14 +77,10 @@ class Behavior : public BT::AsyncActionNode
     return status();
   }
   virtual void halt() override { setStatus(BT::NodeStatus::IDLE); }
-  
+
   /// Method (to be implemented by the user) to implement the function when the satus is RUNNING
   /// User should return the NodeStatus of the action (RUNNING, SUCCESS or FAILURE).
   virtual BT::NodeStatus behaviorRunningProcess() = 0;
-
- private:
-  bool idleToRunning;
-  BT::NodeStatus behaviorStatus;
 };
 
 }  //  namespace mission_control

--- a/mission_control/include/mission_control/mission.h
+++ b/mission_control/include/mission_control/mission.h
@@ -76,6 +76,7 @@ class Mission
   BT::Tree tree_;
   std::string description_;   //  Description of the mission
   std::string behaviorName_;  //  Name of the action (behavior) being executed.
+  BT::NodeStatus behaviorStatus_;
 };
 
 }  //  namespace mission_control

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -45,6 +45,7 @@ using mission_control::Mission;
 Mission::Mission(BT::Tree && missionTree) : tree_(std::move(missionTree))
 {
   description_ = tree_.rootNode()->name();
+  behaviorStatus_ = BT::NodeStatus::IDLE;
 }
 
 Mission::~Mission() {}

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -62,7 +62,11 @@ std::unique_ptr<Mission> Mission::FromMissionDefinition(const std::string& missi
     return nullptr;
 }
 
-void Mission::stop() { tree_.haltTree(); }
+void Mission::stop()
+{
+  tree_.haltTree();
+  behaviorStatus_ = BT::NodeStatus::IDLE;
+}
 
 BT::NodeStatus Mission::getStatus() { return behaviorStatus_; }
 
@@ -70,6 +74,10 @@ std::string Mission::getCurrentMissionDescription() { return description_; }
 
 BT::NodeStatus Mission::Continue()
 {
-  behaviorStatus_ = tree_.tickRoot();
+  if (behaviorStatus_ == BT::NodeStatus::IDLE || behaviorStatus_ == BT::NodeStatus::RUNNING)
+  {
+    behaviorStatus_ = tree_.tickRoot();
+  }
+
   return behaviorStatus_;
 }

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -34,14 +34,15 @@
  *********************************************************************/
 
 // Original version: Christopher Scianna Christopher.Scianna@us.QinetiQ.com
-#include <string>
 #include "mission_control/mission.h"
 
-using mission_control::Mission;
+#include <string>
+
 using BT::NodeStatus;
 using BT::Tree;
+using mission_control::Mission;
 
-Mission::Mission(BT::Tree && missionTree) : tree_(std::move(missionTree))
+Mission::Mission(BT::Tree&& missionTree) : tree_(std::move(missionTree))
 {
   description_ = tree_.rootNode()->name();
 }
@@ -62,8 +63,12 @@ std::unique_ptr<Mission> Mission::FromMissionDefinition(const std::string& missi
 
 void Mission::stop() { tree_.haltTree(); }
 
-BT::NodeStatus Mission::getStatus() { return tree_.rootNode()->status(); }
+BT::NodeStatus Mission::getStatus() { return behaviorStatus_; }
 
 std::string Mission::getCurrentMissionDescription() { return description_; }
 
-BT::NodeStatus Mission::Continue() { return tree_.tickRoot(); }
+BT::NodeStatus Mission::Continue()
+{
+  behaviorStatus_ = tree_.tickRoot();
+  return behaviorStatus_;
+}

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -42,7 +42,7 @@ using BT::NodeStatus;
 using BT::Tree;
 using mission_control::Mission;
 
-Mission::Mission(BT::Tree&& missionTree) : tree_(std::move(missionTree))
+Mission::Mission(BT::Tree && missionTree) : tree_(std::move(missionTree))
 {
   description_ = tree_.rootNode()->name();
 }

--- a/mission_control/src/mission_control.cpp
+++ b/mission_control/src/mission_control.cpp
@@ -145,6 +145,9 @@ void MissionControlNode::executeMissionT(const ros::TimerEvent& timer)
   {
     missionStatus = m_mission_map[currentMissionId]->Continue();
   }
+  else
+    executeMissionTimer.stop();
+    ROS_DEBUG_STREAM("Mission successfully completed");
 }
 
 void MissionControlNode::reportExecuteMissionState(const ros::TimerEvent& timer)
@@ -227,6 +230,7 @@ void MissionControlNode::executeMissionCallback(
       (m_mission_map.count(msg->mission_id) > 0))
   {
     currentMissionId = msg->mission_id;
+    BT::NodeStatus m = m_mission_map[currentMissionId]->Continue();
     executeMissionTimer.start();
     ROS_DEBUG_STREAM("executeMissionCallback - Executing mission id[" << currentMissionId << "]");
   }

--- a/mission_control/src/mission_control.cpp
+++ b/mission_control/src/mission_control.cpp
@@ -116,9 +116,6 @@ int MissionControlNode::abortMission(int missionId)
 {
   if (currentMissionId == missionId)
   {
-    executeMissionTimer.stop();
-    m_mission_map[currentMissionId]->stop();
-
     processAbort();
     ROS_DEBUG_STREAM("Aborting Mission " << currentMissionId);
   }
@@ -141,13 +138,17 @@ void MissionControlNode::reportHeartbeat(const ros::TimerEvent& timer)
 void MissionControlNode::executeMissionT(const ros::TimerEvent& timer)
 {
   NodeStatus missionStatus = m_mission_map[currentMissionId]->getStatus();
-  if (missionStatus != NodeStatus::SUCCESS)
+
+  if (missionStatus == BT::NodeStatus::IDLE || missionStatus == BT::NodeStatus::RUNNING)
   {
     missionStatus = m_mission_map[currentMissionId]->Continue();
   }
-  else
+
+  if (missionStatus == BT::NodeStatus::FAILURE)
+  {
     executeMissionTimer.stop();
-    ROS_DEBUG_STREAM("Mission successfully completed");
+    abortMission(currentMissionId);
+  }
 }
 
 void MissionControlNode::reportExecuteMissionState(const ros::TimerEvent& timer)
@@ -170,10 +171,12 @@ void MissionControlNode::reportExecuteMissionState(const ros::TimerEvent& timer)
         break;
       case BT::NodeStatus::SUCCESS:
         outmsg.execute_mission_state = mission_control::ReportExecuteMissionState::COMPLETE;
+        executeMissionTimer.stop();
+        m_mission_map[currentMissionId]->stop();
         break;
       case BT::NodeStatus::FAILURE:
+        m_mission_map[currentMissionId]->stop();
         outmsg.execute_mission_state = mission_control::ReportExecuteMissionState::ABORTING;
-        abortMission(currentMissionId);
         break;
     }
 
@@ -225,7 +228,6 @@ void MissionControlNode::executeMissionCallback(
       return;
     }
   }
-
   if ((msg->mission_id > 0) && (m_mission_map.size() > 0) &&
       (m_mission_map.count(msg->mission_id) > 0))
   {

--- a/mission_control/src/mission_control.cpp
+++ b/mission_control/src/mission_control.cpp
@@ -230,7 +230,6 @@ void MissionControlNode::executeMissionCallback(
       (m_mission_map.count(msg->mission_id) > 0))
   {
     currentMissionId = msg->mission_id;
-    if(currentMissionId>0) BT::NodeStatus m = m_mission_map[currentMissionId]->Continue();
     executeMissionTimer.start();
     ROS_DEBUG_STREAM("executeMissionCallback - Executing mission id[" << currentMissionId << "]");
   }

--- a/mission_control/src/mission_control.cpp
+++ b/mission_control/src/mission_control.cpp
@@ -230,7 +230,7 @@ void MissionControlNode::executeMissionCallback(
       (m_mission_map.count(msg->mission_id) > 0))
   {
     currentMissionId = msg->mission_id;
-    BT::NodeStatus m = m_mission_map[currentMissionId]->Continue();
+    if(currentMissionId>0) BT::NodeStatus m = m_mission_map[currentMissionId]->Continue();
     executeMissionTimer.start();
     ROS_DEBUG_STREAM("executeMissionCallback - Executing mission id[" << currentMissionId << "]");
   }

--- a/mission_control/test/test_behavior_object.cpp
+++ b/mission_control/test/test_behavior_object.cpp
@@ -19,9 +19,11 @@ class DummyBehavior : public Behavior
   {
     tickCount = 0;
   }
-  BT::NodeStatus behaviorRunningProcess() { 
+  BT::NodeStatus behaviorRunningProcess()
+  {
     tickCount++;
-    return status(); }
+    return status();
+  }
 
   int tickCount;
   void changeStatus(const BT::NodeStatus& newStatus) { setStatus(newStatus); }
@@ -50,12 +52,13 @@ GTEST_TEST(BehaviorTest, TestIfBehaviorStopsAfterHalt)
   ASSERT_TRUE(dummyBehavior.isHalted());
 }
 
-GTEST_TEST(BehaviorTest, TestIfBehaviorChangeStatusToIdleAfterSuccess)
+GTEST_TEST(BehaviorTest, TestIfBehaviorDoesntChangeStatusToIdleAfterSuccess)
 {
   BT::NodeConfiguration nodeConfig;
   DummyBehavior dummyBehavior("dummy", nodeConfig);
   dummyBehavior.changeStatus(BT::NodeStatus::SUCCESS);
-  ASSERT_EQ(dummyBehavior.tick(), BT::NodeStatus::IDLE);
+  dummyBehavior.tick();
+  ASSERT_EQ(dummyBehavior.tick(), BT::NodeStatus::SUCCESS);
 }
 
 GTEST_TEST(BehaviorTest, TestIfBehaviorDontChangeStatusOnTickIfFailure)

--- a/mission_control/test/test_mission_control_behaviors.test
+++ b/mission_control/test/test_mission_control_behaviors.test
@@ -1,0 +1,11 @@
+<launch>
+  <include file="$(find mission_control)/launch/mission_control.launch" />
+  <!--
+      These test verifyes the behaviors/actions:
+        -   Fixed Rudder
+        -   Go to Waypoint
+        -   Depth Heading
+        -   Attitude Servo
+  -->
+  <test test-name="test_mission_control_fixed_rudder_action" pkg="mission_control" type="test_fixed_rudder_behavioral.py" time-limit="10.0" />
+</launch>


### PR DESCRIPTION
# Description
This PR changes the behavior objects to be implemented as ActionNodeBase instead of AsyncActionNode. This PR also:
- Introduce modifications in tests to reflect the change.
- Fix roslint errors

Fixes # (issue)
- [Bug fix]. If the mission wasn't loaded correctly, after an execute command the mission tryes to tick() over an unexisting mission.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing
- [x] Integration tests are passing

# How To Test
**Unit test** 
```sh
catkin_make run_tests_mission_control_gtest
```

**Integration test** 
b) In a second terminal run:
```sh
rostest mission_control test_mission_control_behaviors.test
```

