### PR TITLE
Add message comparison helpers to auv_interfaces package

### DIFF
--- a/auv_interfaces/CMakeLists.txt
+++ b/auv_interfaces/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   geographic_msgs
   geometry_msgs
   message_generation
+  roslint
   std_msgs
 )
 
@@ -41,9 +42,59 @@ generate_messages(
 ## catkin specific configuration ##
 ###################################
 catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}_helpers
   CATKIN_DEPENDS
     geographic_msgs
     geometry_msgs
     message_runtime
     std_msgs
 )
+
+###########
+## Build ##
+###########
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME}_helpers
+  src/helpers.cpp
+)
+
+add_dependencies(${PROJECT_NAME}_helpers
+  ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(${PROJECT_NAME}_helpers ${catkin_LIBRARIES})
+
+#############
+## Install ##
+#############
+
+install(TARGETS ${PROJECT_NAME}_helpers
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+#############
+## Testing ##
+#############
+
+roslint_cpp()
+
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(test_helpers test/test_helpers.cpp)
+  target_link_libraries(test_helpers
+    ${PROJECT_NAME}_helpers ${catkin_LIBRARIES})
+
+  roslint_add_test()
+endif()

--- a/auv_interfaces/include/auv_interfaces/helpers.h
+++ b/auv_interfaces/include/auv_interfaces/helpers.h
@@ -1,0 +1,170 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef AUV_INTERFACES_HELPERS_H
+#define AUV_INTERFACES_HELPERS_H
+
+#include "auv_interfaces/CartesianPose.h"
+#include "auv_interfaces/GeneralizedVector.h"
+#include "auv_interfaces/GeoLocation.h"
+#include "auv_interfaces/ManoeuvringState.h"
+#include "auv_interfaces/MotionPerturbation.h"
+#include "auv_interfaces/SeakeepingState.h"
+#include "auv_interfaces/State.h"
+
+
+namespace auv_interfaces
+{
+
+/// Compare numbers `a` and `b` for approximate equality.
+/**
+ * True if the following equation holds True:
+ *
+ *   \f[ |a - b| <= \left(abs_tol + rel_tol |b|\right) \f]
+ *
+ * Note that comparison is not symmetric in `a` and `b`.
+ */
+bool almost_equal(
+    double a, double b,
+    double abs_tol,
+    double rel_tol);
+
+/// Compare poses `a` and `b` for approximate equality.
+/**
+ * Note that the same tolerances apply to both position and orientation.
+ * Use a non-zero absolute tolerance only to override the relative tolerance
+ * when magnitudes are close to 0.
+ *
+ * \see almost_equal(double,double,double,double)
+ */
+bool almost_equal(
+    const CartesianPose& a,
+    const CartesianPose& b,
+    double abs_tol,
+    double rel_tol);
+
+/// Compare vectors `a` and `b` for approximate equality.
+/**
+ * Note that the same tolerances apply to both linear and angular components.
+ * Use a non-zero absolute tolerance only to override the relative tolerance
+ * when magnitudes are close to 0.
+ *
+ * \see almost_equal(double,double,double,double)
+ */
+bool almost_equal(
+    const GeneralizedVector& a,
+    const GeneralizedVector& b,
+    double abs_tol,
+    double rel_tol);
+
+/// Compare pertubations `a` and `b` for approximate equality.
+/**
+ * Note that the same tolerances apply to both linear and angular components.
+ * Use a non-zero absolute tolerance only to override the relative tolerance
+ * when magnitudes are close to 0.
+ *
+ * \see almost_equal(double,double,double,double)
+ */
+bool almost_equal(
+    const MotionPerturbation& a,
+    const MotionPerturbation& b,
+    double abs_tol,
+    double rel_tol);
+
+/// Compare seakeeping states `a` and `b` for approximate equality.
+/**
+ * Reference frames are checked for equality.
+ *
+ * Note that the same tolerances apply to both linear and angular components.
+ * Use a non-zero absolute tolerance only to override the relative tolerance
+ * when magnitudes are close to 0.
+ *
+ * \see almost_equal(double,double,double,double)
+ */
+bool almost_equal(
+    const SeakeepingState& a,
+    const SeakeepingState& b,
+    double abs_tol,
+    double rel_tol);
+
+/// Compare manoeuvring states `a` and `b` for approximate equality.
+/**
+ * Reference frames are checked for equality.
+ *
+ * Note that the same tolerances apply to both linear and angular components.
+ * Use a non-zero absolute tolerance only to override the relative tolerance
+ * when magnitudes are close to 0.
+ *
+ * \see almost_equal(double,double,double,double)
+ */
+bool almost_equal(
+    const ManoeuvringState& a,
+    const ManoeuvringState& b,
+    double abs_tol,
+    double rel_tol);
+
+
+/// Compare global positions `a` and `b` for approximate equality.
+/**
+ * Note that the same tolerances apply to latitude, longitude, and altitude.
+ * Use a non-zero absolute tolerance only to override the relative tolerance
+ * when magnitudes are close to 0.
+ *
+ * \see almost_equal(double,double,double,double)
+ */
+bool almost_equal(
+    const GeoLocation& a,
+    const GeoLocation& b,
+    double abs_tol,
+    double rel_tol);
+
+/// Compare state `a` and `b` for approximate equality.
+/**
+ * Reference frames are checked for equality.
+ *
+ * Note that the same tolerances apply to all quantities.
+ * Use a non-zero absolute tolerance only to override the
+ * relative tolerance when magnitudes are close to 0.
+ *
+ * \see almost_equal(double,double,double,double)
+ */
+bool almost_equal(
+    const State& a,
+    const State& b,
+    double abs_tol,
+    double rel_tol);
+
+}  // namespace auv_interfaces
+
+#endif  // AUV_INTERFACES_HELPERS_H

--- a/auv_interfaces/package.xml
+++ b/auv_interfaces/package.xml
@@ -15,4 +15,5 @@
   <depend>std_msgs</depend>
   <exec_depend>message_runtime</exec_depend>
   <test_depend>roslint</test_depend>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/auv_interfaces/package.xml
+++ b/auv_interfaces/package.xml
@@ -14,4 +14,5 @@
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <exec_depend>message_runtime</exec_depend>
+  <test_depend>roslint</test_depend>
 </package>

--- a/auv_interfaces/src/helpers.cpp
+++ b/auv_interfaces/src/helpers.cpp
@@ -1,0 +1,144 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <cmath>
+
+#include "auv_interfaces/CartesianPose.h"
+#include "auv_interfaces/GeneralizedVector.h"
+#include "auv_interfaces/GeoLocation.h"
+#include "auv_interfaces/ManoeuvringState.h"
+#include "auv_interfaces/MotionPerturbation.h"
+#include "auv_interfaces/SeakeepingState.h"
+#include "auv_interfaces/State.h"
+
+
+namespace auv_interfaces
+{
+
+bool almost_equal(double a, double b, double abs_tol, double rel_tol)
+{
+  return std::abs(a - b) <= abs_tol + rel_tol * std::abs(b);
+}
+
+static bool almost_equal(
+    const geometry_msgs::Point& a,
+    const geometry_msgs::Point& b,
+    double abs_tol, double rel_tol)
+{
+  return (almost_equal(a.x, b.x, abs_tol, rel_tol) &&
+          almost_equal(a.y, b.y, abs_tol, rel_tol) &&
+          almost_equal(a.z, b.z, abs_tol, rel_tol));
+}
+
+static bool almost_equal(
+    const geometry_msgs::Vector3& a,
+    const geometry_msgs::Vector3& b,
+    double abs_tol, double rel_tol)
+{
+  return (almost_equal(a.x, b.x, abs_tol, rel_tol) &&
+          almost_equal(a.y, b.y, abs_tol, rel_tol) &&
+          almost_equal(a.z, b.z, abs_tol, rel_tol));
+}
+
+bool almost_equal(
+    const CartesianPose& a,
+    const CartesianPose& b,
+    double abs_tol, double rel_tol)
+{
+  // TODO(hidmic): handle orientation singularities
+  return (almost_equal(a.position, b.position, abs_tol, rel_tol) &&
+          almost_equal(a.orientation, b.orientation, abs_tol, rel_tol));
+}
+
+bool almost_equal(
+    const GeneralizedVector& a,
+    const GeneralizedVector& b,
+    double abs_tol, double rel_tol)
+{
+  return (almost_equal(a.linear, b.linear, abs_tol, rel_tol) &&
+          almost_equal(a.angular, b.angular, abs_tol, rel_tol));
+}
+
+bool almost_equal(
+    const MotionPerturbation& a,
+    const MotionPerturbation& b,
+    double abs_tol, double rel_tol)
+{
+  return (almost_equal(a.displacement.mean, b.displacement.mean, abs_tol, rel_tol) &&
+          almost_equal(a.rate.mean, b.rate.mean, abs_tol, rel_tol));
+}
+
+bool almost_equal(
+    const SeakeepingState& a,
+    const SeakeepingState& b,
+    double abs_tol, double rel_tol)
+{
+  return ((a.reference_frame_id == b.reference_frame_id) &&
+          almost_equal(a.perturbation, b.perturbation, abs_tol, rel_tol));
+}
+
+bool almost_equal(
+    const ManoeuvringState& a,
+    const ManoeuvringState& b,
+    double abs_tol, double rel_tol)
+{
+  return ((a.reference_frame_id == b.reference_frame_id) &&
+          almost_equal(a.pose.mean, b.pose.mean, abs_tol, rel_tol) &&
+          almost_equal(a.velocity.mean, b.velocity.mean, abs_tol, rel_tol));
+}
+
+static bool almost_equal(const geographic_msgs::GeoPoint& a,
+                  const geographic_msgs::GeoPoint& b,
+                  double abs_tol, double rel_tol)
+{
+  return (almost_equal(a.latitude, b.latitude, abs_tol, rel_tol) &&
+          almost_equal(a.longitude, b.longitude, abs_tol, rel_tol) &&
+          almost_equal(a.altitude, b.altitude, abs_tol, rel_tol));
+}
+
+bool almost_equal(const GeoLocation& a, const GeoLocation& b,
+                  double abs_tol, double rel_tol)
+{
+  return almost_equal(a.position, b.position, abs_tol, rel_tol);
+}
+
+bool almost_equal(const State& a, const State& b,
+                  double abs_tol, double rel_tol)
+{
+  return (almost_equal(a.geolocation, b.geolocation, abs_tol, rel_tol) &&
+          almost_equal(a.manoeuvring, b.manoeuvring, abs_tol, rel_tol) &&
+          almost_equal(a.seakeeping, b.seakeeping, abs_tol, rel_tol));
+}
+
+}  // namespace auv_interfaces

--- a/auv_interfaces/test/test_helpers.cpp
+++ b/auv_interfaces/test/test_helpers.cpp
@@ -1,0 +1,94 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "auv_interfaces/helpers.h"
+
+
+TEST(AuvInterfacesHelpers, compare_default_states)
+{
+  auv_interfaces::State state;
+  auv_interfaces::State another_state;
+
+  constexpr double zero_tol = 0.;
+  EXPECT_TRUE(auv_interfaces::almost_equal(
+      state, another_state, zero_tol, zero_tol));
+
+  constexpr double abs_tol = 0.;
+  constexpr double rel_tol = 0.01;  // 1%
+  EXPECT_TRUE(auv_interfaces::almost_equal(
+      state, another_state, abs_tol, rel_tol));
+}
+
+
+TEST(AuvInterfacesHelpers, compare_non_default_states)
+{
+  auv_interfaces::State state_at_t0;
+  state_at_t0.manoeuvring.pose.mean.position.x = 0.0;
+  auv_interfaces::State state_at_t1;
+  state_at_t1.manoeuvring.pose.mean.position.x = 1.0;
+
+  constexpr double abs_tol = 0.01;
+  constexpr double rel_tol = 0.01;  // 1%
+  EXPECT_FALSE(auv_interfaces::almost_equal(
+      state_at_t0, state_at_t1, abs_tol, rel_tol));
+
+  auv_interfaces::State state_at_t2;
+  state_at_t2.manoeuvring.pose.mean.position.x = 1.0;
+  state_at_t2.manoeuvring.pose.mean.orientation.z = 0.001;
+  EXPECT_TRUE(auv_interfaces::almost_equal(
+      state_at_t1, state_at_t2, abs_tol, rel_tol));
+}
+
+
+TEST(AuvInterfacesHelpers, compare_states_in_different_frames)
+{
+  auv_interfaces::State state_in_frame_a;
+  state_in_frame_a.seakeeping.reference_frame_id = "a";
+  auv_interfaces::State state_in_frame_b;
+  state_in_frame_b.seakeeping.reference_frame_id = "b";
+
+  constexpr double zero_tol = 0.;
+  constexpr double rel_tol = 1.;  // 100%
+  EXPECT_FALSE(auv_interfaces::almost_equal(
+      state_in_frame_a, state_in_frame_b, zero_tol, rel_tol));
+}
+
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Description

Precisely what the title says. These helpers aid stagnation checks in publishers.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Run unit tests for `auv_interfaces` package:

```sh
catkin_make run_tests_auv_interfaces
``` 