### PR TITLE
Replace pose_estimator::CorrectedData with auv_interfaces::StateStamped

### DIFF
--- a/autopilot/CMakeLists.txt
+++ b/autopilot/CMakeLists.txt
@@ -6,8 +6,8 @@ set(NODE_APP_NAME ${PROJECT_NAME}_node)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
+  auv_interfaces
   fin_control
-  pose_estimator
   roscpp
   rospy
   roslint
@@ -27,7 +27,6 @@ generate_messages(
   DEPENDENCIES
   fin_control
   thruster_control
-  pose_estimator
   jaus_ros_bridge
   sensor_msgs
   std_msgs
@@ -35,7 +34,7 @@ generate_messages(
 
 catkin_package(
  INCLUDE_DIRS include
- CATKIN_DEPENDS fin_control pose_estimator roscpp rospy std_msgs thruster_control jaus_ros_bridge mission_manager
+ CATKIN_DEPENDS auv_interfaces fin_control roscpp rospy std_msgs thruster_control jaus_ros_bridge mission_manager
 )
 
 roslint_cpp(

--- a/autopilot/include/autopilot/autopilot.h
+++ b/autopilot/include/autopilot/autopilot.h
@@ -43,7 +43,6 @@
 
 #include <autopilot/AutoPilotInControl.h>
 #include <math.h>
-#include <pose_estimator/CorrectedData.h>
 #include <ros/ros.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -55,6 +54,7 @@
 #include <sstream>
 
 #include "autopilot/pid.h"
+#include "auv_interfaces/StateStamped.h"
 #include "fin_control/ReportAngle.h"
 #include "fin_control/SetAngles.h"
 #include "jaus_ros_bridge/ActivateManualControl.h"
@@ -85,7 +85,7 @@ class AutoPilotNode
 
   ros::Subscriber jausRosSub;
 
-  ros::Subscriber correctedDataSub;
+  ros::Subscriber stateSub;
   ros::Subscriber missionStatusSub;
   ros::Timer missionMgrHeartbeatTimer;
 
@@ -126,7 +126,7 @@ class AutoPilotNode
   double depthIMax;
   double depthIMin;
 
-  void correctedDataCallback(const pose_estimator::CorrectedData& data);
+  void stateCallback(const auv_interfaces::StateStamped& msg);
   void missionStatusCallback(const mission_manager::ReportExecuteMissionState& data);
 
   void HandleActivateManualControl(const jaus_ros_bridge::ActivateManualControl& data);

--- a/autopilot/package.xml
+++ b/autopilot/package.xml
@@ -9,8 +9,8 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>auv_interfaces</build_depend>
   <build_depend>fin_control</build_depend>
-  <build_depend>pose_estimator</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>rospy</build_depend>
@@ -19,16 +19,16 @@
   <build_depend>jaus_ros_bridge</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>mission_manager</build_depend>
+  <build_export_depend>auv_interfaces</build_export_depend>
   <build_export_depend>fin_control</build_export_depend>
-  <build_export_depend>pose_estimator</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>thruster_control</build_export_depend>
   <build_export_depend>jaus_ros_bridge</build_export_depend>
   <build_export_depend>mission_manager</build_export_depend>
+  <exec_depend>auv_interfaces</exec_depend>
   <exec_depend>fin_control</exec_depend>
-  <exec_depend>pose_estimator</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/jaus_ros_bridge/CMakeLists.txt
+++ b/jaus_ros_bridge/CMakeLists.txt
@@ -12,6 +12,7 @@ project(jaus_ros_bridge)
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
+  auv_interfaces
   roscpp
   rospy
   sensor_msgs
@@ -129,7 +130,7 @@ catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES jaus_ros_bridge
 #  LIBRARIES fin_control
-  CATKIN_DEPENDS roscpp rospy sensor_msgs std_msgs health_monitor fin_control
+  CATKIN_DEPENDS auv_interfaces roscpp rospy sensor_msgs std_msgs health_monitor fin_control
 #  DEPENDS system_lib
 )
 

--- a/jaus_ros_bridge/include/ReportPoseEstimatorData.h
+++ b/jaus_ros_bridge/include/ReportPoseEstimatorData.h
@@ -33,11 +33,12 @@
  *********************************************************************/
 
 // Original version: Jie Sun <Jie.Sun@us.QinetiQ.com>
+// TODO(hidmic): migrate to ReportState
 
 #ifndef REPORTPOSEESTIMATORDATA_H
 #define REPORTPOSEESTIMATORDATA_H
 
-#include <pose_estimator/CorrectedData.h>
+#include <auv_interfaces/StateStamped.h>
 #include "JausMessageOut.h"
 
 struct PoseEstimatorData {
@@ -52,13 +53,12 @@ struct PoseEstimatorData {
 class ReportPoseEstimatorData : public JausMessageOut {
  private:
   PoseEstimatorData m_poseData;
-  ros::Subscriber _subscriber_reportPoseData;
-  bool HasNewData(const pose_estimator::CorrectedData::ConstPtr& msg);
+  ros::Subscriber _subscriber_state;
 
  public:
   void init(ros::NodeHandle* nodeHandle, udpserver* udp);
 
-  void handleReportPoseEstimatorData(const pose_estimator::CorrectedData::ConstPtr& msg);
+  void handleState(const auv_interfaces::StateStamped::ConstPtr& msg);
 
   virtual DataInfo GetPackedMessage(void* data);
   virtual void Reset();

--- a/jaus_ros_bridge/package.xml
+++ b/jaus_ros_bridge/package.xml
@@ -52,16 +52,17 @@
  <!--  <depend>thruster_control</depend> -->
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>auv_interfaces</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>fin_control</build_depend>
   <build_depend>thruster_control</build_depend>
-  <build_depend>pose_estimator</build_depend>
   <build_depend>mission_manager</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>health_monitor</build_depend>
+  <build_export_depend>auv_interfaces</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
@@ -69,15 +70,14 @@
   <build_export_depend>fin_control</build_export_depend>
   <build_export_depend>thruster_control</build_export_depend>
   <build_export_depend>mission_manager</build_export_depend>
-  <build_export_depend>pose_estimator</build_export_depend>
   <build_export_depend>health_monitor</build_export_depend>
+  <exec_depend>auv_interfaces</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>fin_control</exec_depend>
   <exec_depend>thruster_control</exec_depend>
-  <exec_depend>pose_estimator</exec_depend>
   <exec_depend>mission_manager</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>health_monitor</exec_depend>

--- a/mission_manager/CMakeLists.txt
+++ b/mission_manager/CMakeLists.txt
@@ -7,8 +7,8 @@ add_compile_options(-std=c++11)
 add_compile_options(-DTIXML_USE_STL)
 
 find_package(catkin REQUIRED COMPONENTS
+  auv_interfaces
   health_monitor
-  pose_estimator
   payload_manager
   roscpp
   roslint
@@ -40,14 +40,13 @@ add_message_files(
 
 generate_messages(
   DEPENDENCIES
-  pose_estimator
   payload_manager
   std_msgs
 )
 
 catkin_package(
  INCLUDE_DIRS include
- CATKIN_DEPENDS pose_estimator payload_manager roscpp rospy std_msgs
+ CATKIN_DEPENDS payload_manager roscpp rospy std_msgs
 )
 
 ###########

--- a/mission_manager/include/mission_manager/behavior.h
+++ b/mission_manager/include/mission_manager/behavior.h
@@ -48,7 +48,7 @@
 #include <map>
 #include <string>
 
-#include "pose_estimator/CorrectedData.h"
+#include "auv_interfaces/StateStamped.h"
 #include "std_msgs/Header.h"
 #include "tinyxml/tinyxml.h"
 
@@ -138,7 +138,7 @@ class Behavior
 
   // Message-type behavior implementation overrides
   virtual void publishMsg() { }
-  virtual bool checkCorrectedData(const pose_estimator::CorrectedData& data) { return true; }
+  virtual bool checkState(const auv_interfaces::StateStamped& data) { return true; }
 
   // Service-type behavior implementation overrides
   virtual void callService() { }

--- a/mission_manager/include/mission_manager/behaviors/altitude_heading.h
+++ b/mission_manager/include/mission_manager/behaviors/altitude_heading.h
@@ -67,7 +67,7 @@ class AltitudeHeadingBehavior : public Behavior
   virtual bool parseMissionFileParams();
   bool getParams(ros::NodeHandle nh);
   virtual void publishMsg();
-  bool checkCorrectedData(const pose_estimator::CorrectedData& data);
+  bool checkState(const auv_interfaces::StateStamped& data);
 
  private:
   ros::Publisher altitude_heading_behavior_pub;

--- a/mission_manager/include/mission_manager/behaviors/attitude_servo.h
+++ b/mission_manager/include/mission_manager/behaviors/attitude_servo.h
@@ -67,7 +67,7 @@ class AttitudeServoBehavior : public Behavior
   virtual bool parseMissionFileParams();
   bool getParams(ros::NodeHandle nh);
   virtual void publishMsg();
-  bool checkCorrectedData(const pose_estimator::CorrectedData& data);
+  bool checkState(const auv_interfaces::StateStamped& data);
 
  private:
   ros::Publisher attitude_servo_behavior_pub;

--- a/mission_manager/include/mission_manager/behaviors/depth_heading.h
+++ b/mission_manager/include/mission_manager/behaviors/depth_heading.h
@@ -67,7 +67,7 @@ class DepthHeadingBehavior : public Behavior
   virtual void publishMsg();
 
   bool getParams(ros::NodeHandle nh);
-  bool checkCorrectedData(const pose_estimator::CorrectedData& data);
+  bool checkState(const auv_interfaces::StateStamped& data);
 
  private:
   ros::Publisher depth_heading_behavior_pub;

--- a/mission_manager/include/mission_manager/behaviors/fixed_rudder.h
+++ b/mission_manager/include/mission_manager/behaviors/fixed_rudder.h
@@ -67,7 +67,7 @@ class FixedRudderBehavior : public Behavior
   virtual void publishMsg();
 
   bool getParams(ros::NodeHandle nh);
-  bool checkCorrectedData(const pose_estimator::CorrectedData& data);
+  bool checkState(const auv_interfaces::StateStamped& data);
 
  private:
   ros::Publisher fixed_rudder_behavior_pub;

--- a/mission_manager/include/mission_manager/behaviors/payload_command.h
+++ b/mission_manager/include/mission_manager/behaviors/payload_command.h
@@ -64,7 +64,7 @@ class PayloadCommandBehavior : public Behavior
   bool getParams(ros::NodeHandle nh);
 
   virtual void publishMsg();
-  bool checkCorrectedData(const pose_estimator::CorrectedData& data);
+  bool checkState(const auv_interfaces::StateStamped& data);
 
  private:
   ros::Publisher payload_command_behavior_pub;

--- a/mission_manager/include/mission_manager/behaviors/waypoint.h
+++ b/mission_manager/include/mission_manager/behaviors/waypoint.h
@@ -67,7 +67,7 @@ class WaypointBehavior : public Behavior
   bool getParams(ros::NodeHandle nh);
 
   virtual void publishMsg();
-  bool checkCorrectedData(const pose_estimator::CorrectedData& data);
+  bool checkState(const auv_interfaces::StateStamped& data);
 
  private:
   ros::Publisher waypoint_behavior_pub;

--- a/mission_manager/include/mission_manager/mission.h
+++ b/mission_manager/include/mission_manager/mission.h
@@ -76,7 +76,7 @@ class Mission
 
   boost::shared_ptr<boost::thread> m_threadProcMission, m_threadAbortMission;
 
-  void ProcessCorrectedPoseData(const pose_estimator::CorrectedData &data);
+  void ProcessState(const auv_interfaces::StateStamped &data);
 
   void setMissionDescription(std::string descStr) { m_mission_description = descStr; }
   std::string getMissionDescription() { return m_mission_description; }

--- a/mission_manager/package.xml
+++ b/mission_manager/package.xml
@@ -8,24 +8,24 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>auv_interfaces</build_depend>
   <build_depend>health_monitor</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>payload_manager</build_depend>
-  <build_depend>pose_estimator</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_export_depend>auv_interfaces</build_export_depend>
   <build_export_depend>health_monitor</build_export_depend>
   <build_export_depend>payload_manager</build_export_depend>
-  <build_export_depend>pose_estimator</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>auv_interfaces</exec_depend>
   <exec_depend>health_monitor</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>payload_manager</exec_depend>
-  <exec_depend>pose_estimator</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/mission_manager/src/behaviors/altitude_heading.cpp
+++ b/mission_manager/src/behaviors/altitude_heading.cpp
@@ -150,11 +150,12 @@ void AltitudeHeadingBehavior::publishMsg()
   altitude_heading_behavior_pub.publish(msg);
 }
 
-bool AltitudeHeadingBehavior::checkCorrectedData(const pose_estimator::CorrectedData& data)
+bool AltitudeHeadingBehavior::checkState(const auv_interfaces::StateStamped& data)
 {
   // A quick check to see if our RPY angles match
   // tjw debug  if (m_depth_ena && (abs(m_depth - data.depth) > m_depth_tol)) return false;
-  if (m_heading_ena && (abs(m_heading - data.rpy_ang.z) > m_heading_tol))
+  double heading = data.state.manoeuvring.pose.mean.orientation.z;
+  if (m_heading_ena && (abs(m_heading - heading) > m_heading_tol))
   {
     ROS_INFO("heading corrected data returning false");
     return false;

--- a/mission_manager/src/behaviors/attitude_servo.cpp
+++ b/mission_manager/src/behaviors/attitude_servo.cpp
@@ -177,12 +177,15 @@ void AttitudeServoBehavior::publishMsg()
   attitude_servo_behavior_pub.publish(msg);
 }
 
-bool AttitudeServoBehavior::checkCorrectedData(const pose_estimator::CorrectedData& data)
+bool AttitudeServoBehavior::checkState(const auv_interfaces::StateStamped& data)
 {
   // A quick check to see if our RPY angles match
-  if (m_roll_ena && (abs(m_roll - data.rpy_ang.x) > m_roll_tol)) return false;
-  if (m_pitch_ena && (abs(m_pitch - data.rpy_ang.y) > m_pitch_tol)) return false;
-  if (m_yaw_ena && (abs(m_yaw - data.rpy_ang.z) > m_yaw_tol)) return false;
+  double roll = data.state.manoeuvring.pose.mean.orientation.x;
+  double pitch = data.state.manoeuvring.pose.mean.orientation.y;
+  double yaw = data.state.manoeuvring.pose.mean.orientation.z;
+  if (m_roll_ena && (abs(m_roll - roll) > m_roll_tol)) return false;
+  if (m_pitch_ena && (abs(m_pitch - pitch) > m_pitch_tol)) return false;
+  if (m_yaw_ena && (abs(m_yaw - yaw) > m_yaw_tol)) return false;
 
   // TODO(QNA): check shaft speed and/or battery position?
   // TODO(QNA): make sure our RPY rates are close to zero?

--- a/mission_manager/src/behaviors/depth_heading.cpp
+++ b/mission_manager/src/behaviors/depth_heading.cpp
@@ -150,11 +150,12 @@ void DepthHeadingBehavior::publishMsg()
   depth_heading_behavior_pub.publish(msg);
 }
 
-bool DepthHeadingBehavior::checkCorrectedData(const pose_estimator::CorrectedData& data)
+bool DepthHeadingBehavior::checkState(const auv_interfaces::StateStamped& data)
 {
   // A quick check to see if our RPY angles match
   // tjw debug  if (m_depth_ena && (abs(m_depth - data.depth) > m_depth_tol)) return false;
-  if (m_heading_ena && (abs(m_heading - data.rpy_ang.z) > m_heading_tol))
+  double heading = data.state.manoeuvring.pose.mean.orientation.z;
+  if (m_heading_ena && (abs(m_heading - heading) > m_heading_tol))
   {
     ROS_INFO("heading corrected data returning false");
     return false;

--- a/mission_manager/src/behaviors/fixed_rudder.cpp
+++ b/mission_manager/src/behaviors/fixed_rudder.cpp
@@ -166,7 +166,7 @@ void FixedRudderBehavior::publishMsg()
   fixed_rudder_behavior_pub.publish(msg);
 }
 
-bool FixedRudderBehavior::checkCorrectedData(const pose_estimator::CorrectedData& data)
+bool FixedRudderBehavior::checkState(const auv_interfaces::StateStamped& data)
 {
   // A quick check to see if our depth matches, note: rudder is not part of corrected data.
   // TODO(QNA): put back in when depth working  if (m_depth_ena && (abs(m_depth - data.depth) >

--- a/mission_manager/src/behaviors/payload_command.cpp
+++ b/mission_manager/src/behaviors/payload_command.cpp
@@ -93,7 +93,7 @@ void PayloadCommandBehavior::publishMsg()
   payload_command_behavior_pub.publish(msg);
 }
 
-bool PayloadCommandBehavior::checkCorrectedData(const pose_estimator::CorrectedData& data)
+bool PayloadCommandBehavior::checkState(const auv_interfaces::StateStamped& data)
 {
   return true;
 }

--- a/mission_manager/src/behaviors/waypoint.cpp
+++ b/mission_manager/src/behaviors/waypoint.cpp
@@ -268,7 +268,7 @@ void WaypointBehavior::publishMsg()
   waypoint_behavior_pub.publish(msg);
 }
 
-bool WaypointBehavior::checkCorrectedData(const pose_estimator::CorrectedData& data)
+bool WaypointBehavior::checkState(const auv_interfaces::StateStamped& data)
 {
   if (m_behavior_done)
   {
@@ -281,7 +281,9 @@ bool WaypointBehavior::checkCorrectedData(const pose_estimator::CorrectedData& d
   double desiredNorthing;
   double desiredEasting;
 
-  latLongtoUTM(data.position.latitude, data.position.longitude, &currentNorthing, &currentEasting);
+  double latitude = data.state.geolocation.position.latitude;
+  double longitude = data.state.geolocation.position.longitude;
+  latLongtoUTM(latitude, longitude, &currentNorthing, &currentEasting);
   latLongtoUTM(m_lat, m_long, &desiredNorthing, &desiredEasting);
 
   // formula for distance between two 3D points is d=sqrt((x2-x1)^2 + (y2-y1)^2 + (z2-z1)^2)
@@ -290,9 +292,9 @@ bool WaypointBehavior::checkCorrectedData(const pose_estimator::CorrectedData& d
   //   dist_to_wp = std::hypot((currentNorthing-desiredNorthing, currentEasting-desiredEasting,
   //   data.depth-m_depth);
   // dist_to_wp = hypot(abs(currentNorthing-desiredNorthing), abs(currentEasting-desiredEasting));
-
+  double depth = data.state.manoeuvring.pose.mean.position.z;
   dist_to_wp = sqrt(pow((currentNorthing - desiredNorthing), 2) +
-                    pow((currentEasting - desiredEasting), 2) + pow((data.depth - m_depth), 2));
+                    pow((currentEasting - desiredEasting), 2) + pow((depth - m_depth), 2));
 
   if (dist_to_wp < m_wp_radius)
   {

--- a/mission_manager/src/mission.cpp
+++ b/mission_manager/src/mission.cpp
@@ -149,14 +149,14 @@ Behavior* Mission::getNextAbortBehavior(bool reset)
   return *m_abort_behavior_iterator++;
 }
 
-void Mission::ProcessCorrectedPoseData(const pose_estimator::CorrectedData& data)
+void Mission::ProcessState(const auv_interfaces::StateStamped& data)
 {
   if (m_current_behavior == NULL) return;
 
   if ((GetState() != MissionState::ABORTING) && (GetState() != MissionState::EXECUTING)) return;
 
   boost::mutex::scoped_lock callback_lock(m_mutCallbacks);
-  if (m_current_behavior->checkCorrectedData(data)) callBackTmr.stop();
+  if (m_current_behavior->checkState(data)) callBackTmr.stop();
   callback_lock.unlock();
 }
 


### PR DESCRIPTION
# Description

Precisely what the title says. This patch transitions the entire code base to operate with `auv_interfaces` messages, which will then enable us to either `pose_estimator` or `ixblue_c3_ins` interchangeably.

Depends on #91. 

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

This is a breaking change for which there are no comprehensive enough tests. Full manual QA is necessary.