### PR TITLE
Drop extra diagnostics from ixblue_c3_ins node

### DIFF
--- a/ixblue_c3_ins/include/ixblue_c3_ins/ixblue_c3_ins.h
+++ b/ixblue_c3_ins/include/ixblue_c3_ins/ixblue_c3_ins.h
@@ -16,9 +16,7 @@
 
 #include <auv_interfaces/StateStamped.h>
 #include <diagnostic_tools/diagnosed_publisher.h>
-#include <diagnostic_tools/health_check.h>
 #include <diagnostic_updater/diagnostic_updater.h>
-#include <health_monitor/ReportFault.h>
 
 #include "ixblue_c3_ins/c3_protocol.h"
 
@@ -43,9 +41,6 @@ private:
 
   qna::diagnostic_tools::DiagnosedPublisher<
     auv_interfaces::StateStamped> state_pub_;
-  qna::diagnostic_tools::HealthCheck<double> orientation_roll_check_;
-  qna::diagnostic_tools::HealthCheck<double> orientation_pitch_check_;
-  qna::diagnostic_tools::HealthCheck<double> orientation_yaw_check_;
   diagnostic_updater::Updater diagnostics_updater_;
 
   int fd_;  // Listening UDP socket to "consume" data from the INS


### PR DESCRIPTION
# Description

As per offline discussion, this patch removes diagnostic checks that belong to the `pose_estimator` node from the `ixblue_c3_ins` node. INS

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

1. Induce a rate check error by executing the `ixblue_c3_ins` node with bad parameters

```sh
rosrun ixblue_c3_ins ixblue3_c3_ins_node _max_rate:=1 _min_rate:=0 
```

2. Check error shows up in `/diagnostics` but **without** a fault code.