### PR TITLE
Use INS depth measurement if any

### DIFF
--- a/ixblue_c3_ins/src/ros_helpers.cpp
+++ b/ixblue_c3_ins/src/ros_helpers.cpp
@@ -95,6 +95,10 @@ to_ros_message(const c3_protocol::nav_long::nav_long_data_t& data)
   msg.geolocation.covariance[8] = std::pow(data.altitude_err_sd, 2);
 
   // TODO(hidmic): add terrestrial reference frame
+  if (data.algo_status[0] & 0x20)  // depth sensor in use
+  {
+    msg.manoeuvring.pose.mean.position.z = -data.altitude;  // flip z-axis
+  }
   msg.manoeuvring.pose.mean.orientation.x = data.roll;
   msg.manoeuvring.pose.mean.orientation.y = -data.pitch;  // flip y-axis
   msg.manoeuvring.pose.mean.orientation.z = wrap_to_pi(data.heading);


### PR DESCRIPTION
# Description

This patch populates depth information from INS altitude estimates if and only if these are coming from a depth sensor.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

1. Launch `ixblue_c3_ins` node:

```sh
roslaunch system_bringup ins.launch
```

2. Verify that the INS state shows a non-zero mean position along the z-axis.