### PR TITLE
Mission control aborting routine

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mission_control)
 
-set(NODE_APP_NAME ${PROJECT_NAME}_node)
-
 add_compile_options(-std=c++11)
-add_compile_options(-DTIXML_USE_STL)
 
 find_package(catkin REQUIRED COMPONENTS
   actionlib
@@ -62,31 +59,24 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_executable(${NODE_APP_NAME} 
-   src/mission.cpp
-   src/mission_control.cpp
-   src/mission_control_main.cpp
-   src/behaviors/waypoint.cpp
-   src/behaviors/fixed_rudder.cpp
-   src/behaviors/depth_heading.cpp
-   src/behaviors/attitude_servo.cpp
-)
-
-add_library(MISSION_CONTROL_LIB SHARED
+add_library(${PROJECT_NAME} SHARED
   src/mission.cpp
   src/mission_control.cpp
-  src/mission_control_main.cpp
   src/behaviors/waypoint.cpp
   src/behaviors/fixed_rudder.cpp
   src/behaviors/depth_heading.cpp
   src/behaviors/attitude_servo.cpp
 )
 
-add_dependencies(${NODE_APP_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
-target_link_libraries(${NODE_APP_NAME}
-  ${catkin_LIBRARIES}
+set(NODE_APP_NAME ${PROJECT_NAME}_node)
+add_executable(${NODE_APP_NAME}
+   src/mission_control_main.cpp
 )
+
+target_link_libraries(${NODE_APP_NAME} ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 roslint_cpp()
 
@@ -94,14 +84,14 @@ roslint_cpp()
 ## Install ##
 #############
 
-install(TARGETS ${NODE_APP_NAME}
+install(TARGETS ${PROJECT_NAME} ${NODE_APP_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(FILES
-  launch/mission_control.launch
+install(DIRECTORY
+  launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
@@ -109,17 +99,14 @@ install(FILES
 ## Testing ##
 #############
 
-
 if(CATKIN_ENABLE_TESTING)
-roslint_add_test()
+  roslint_add_test()
 
-find_package(rostest REQUIRED)
-add_rostest(test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test)
-add_rostest(test/test_jaus_ros_bridge_interface_mission_control.test)
-add_rostest(test/test_mission_control_publishes_heartbeat.test)
-add_rostest(test/test_mission_control_behaviors.test)
-
-catkin_add_gtest(behavior-object-test test/test_behavior_object.cpp)
-target_link_libraries(behavior-object-test ${catkin_LIBRARIES} ${MISSION_CONTROL_LIB})
-
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test)
+  add_rostest(test/test_jaus_ros_bridge_interface_mission_control.test)
+  add_rostest(test/test_mission_control_publishes_heartbeat.test)
+  add_rostest(test/test_mission_control_behaviors.test)
+  catkin_add_gtest(behavior-object-test test/test_behavior_object.cpp)
+  target_link_libraries(behavior-object-test ${catkin_LIBRARIES} ${PROJECT_NAME})
 endif()

--- a/mission_control/include/mission_control/mission.h
+++ b/mission_control/include/mission_control/mission.h
@@ -38,6 +38,7 @@
 #define MISSION_CONTROL_MISSION_H
 
 #include <behaviortree_cpp_v3/bt_factory.h>
+
 #include <memory>
 #include <string>
 
@@ -64,14 +65,14 @@ class Mission
     COMPLETE
   };
 
-  BT::NodeStatus Continue();
+  void Continue();
   void stop();
 
   BT::NodeStatus getStatus();
   std::string getCurrentMissionDescription();
 
  private:
-  explicit Mission(BT::Tree && missionTree);
+  explicit Mission(BT::Tree&& missionTree);
 
   BT::Tree tree_;
   std::string description_;   //  Description of the mission

--- a/mission_control/include/mission_control/mission.h
+++ b/mission_control/include/mission_control/mission.h
@@ -42,42 +42,46 @@
 #include <memory>
 #include <string>
 
-// Behaviors
-#include "mission_control/behaviors/waypoint.h"
 
 namespace mission_control
 {
+
 class Mission
 {
- public:
-  static std::unique_ptr<Mission> FromMissionDefinition(const std::string& missionFullPath,
-                                                        BT::BehaviorTreeFactory& missionFactory);
-
-  ~Mission();
-
-  enum class State
+public:
+  enum class Status
   {
     READY,
+    PENDING,
     EXECUTING,
     ABORTING,
-    STOPPED,
-    PAUSED,
-    COMPLETE
+    COMPLETED,
+    ABORTED,
+    PREEMPTED
   };
 
-  void Continue();
-  void stop();
+  static std::unique_ptr<Mission> fromFile(const std::string& path);
 
-  BT::NodeStatus getStatus();
-  std::string getCurrentMissionDescription();
+  inline int id() const { return id_; }
+  inline Status status() const { return status_; }
+  const std::string& description() const;
+  bool active() const;
 
- private:
-  explicit Mission(BT::Tree&& missionTree);
+  Mission& start();
+  Mission& resume();
+  Mission& preempt();
+  Mission& abort();
 
-  BT::Tree tree_;
-  std::string description_;   //  Description of the mission
-  std::string behaviorName_;  //  Name of the action (behavior) being executed.
-  BT::NodeStatus behaviorStatus_;
+private:
+  explicit Mission(BT::Tree&& tree);  // NOLINT
+
+  BT::Tree main_behavior_tree_;
+  BT::Tree abort_behavior_tree_;
+
+  Status status_;
+  int id_;
+
+  static int id_sequence_;
 };
 
 }  //  namespace mission_control

--- a/mission_control/include/mission_control/mission_control.h
+++ b/mission_control/include/mission_control/mission_control.h
@@ -105,6 +105,7 @@ class MissionControlNode
   ros::Publisher pub_report_missions;
   ros::Publisher pub_report_heartbeat;
   ros::Publisher pub_activate_manual_control;
+  ros::Publisher pub_attitude_servo;
 
   ros::Timer reportExecuteMissionStateTimer;
   Mission::State last_state;
@@ -139,12 +140,11 @@ private:
   double reportExecuteMissionStateRate;
   double reportHeartbeatRate;
   double executeMissionAsynchronousRate;
+  double maxCtrlFinAngle;
 
   int currentMissionId;
   int MissionIdCounter;
-
-  int m_current_mission_id;
-  int m_mission_id_counter;
+  int missionState;
 
   std::unordered_map<int, std::unique_ptr<Mission>> m_mission_map;
   uint64_t heartbeat_sequence_id;

--- a/mission_control/include/mission_control/mission_control.h
+++ b/mission_control/include/mission_control/mission_control.h
@@ -68,87 +68,60 @@
 #include "mission_control/behavior.h"
 #include "mission_control/mission.h"
 
-#include "mission_control/behaviors/waypoint.h"
-#include "mission_control/behaviors/fixed_rudder.h"
-#include "mission_control/behaviors/depth_heading.h"
-#include "mission_control/behaviors/attitude_servo.h"
-
-#define LOGGING (1)
-
 #define NODE_VERSION "1.0x"
 
-using BT::NodeStatus;
-using BT::Tree;
-using mission_control::LoadMission;
-using mission_control::Mission;
-using mission_control::MissionData;
-using mission_control::ReportExecuteMissionState;
-using mission_control::ReportHeartbeat;
-using mission_control::ReportLoadMissionState;
-using mission_control::ReportMissions;
+
+namespace mission_control
+{
 
 class MissionControlNode
 {
- public:
-  ros::Subscriber sub_corrected_data;
+public:
+  MissionControlNode();
 
-  ros::Subscriber report_fault_sub;
-
-  ros::Subscriber load_mission_sub;
-  ros::Subscriber execute_mission_sub;
-  ros::Subscriber abort_mission_sub;
-  ros::Subscriber query_mission_sub;
-  ros::Subscriber remove_mission_sub;
-
-  ros::Publisher pub_report_mission_load_state;
-  ros::Publisher pub_report_mission_execute_state;
-  ros::Publisher pub_report_missions;
-  ros::Publisher pub_report_heartbeat;
-  ros::Publisher pub_activate_manual_control;
-  ros::Publisher pub_attitude_servo;
-
-  ros::Timer reportExecuteMissionStateTimer;
-  Mission::State last_state;
-
-  ros::Timer reportHeartbeatTimer;
-  ros::Timer executeMissionTimer;
-
-  explicit MissionControlNode(ros::NodeHandle& h);
-  ~MissionControlNode();
-
-  int loadMissionFile(std::string mission_full_path);
-  int executeMission(int missionId);
-  int abortMission(int missionId);
-  void processAbort();
-  int stopMission();
-
-  void reportHeartbeat(const ros::TimerEvent& timer);
-  void executeMissionT(const ros::TimerEvent& timer);
-  void reportExecuteMissionState(const ros::TimerEvent& timer);
-  void loadMissionCallback(const mission_control::LoadMission::ConstPtr& msg);
-  void executeMissionCallback(const mission_control::ExecuteMission::ConstPtr& msg);
-  void abortMissionCallback(const mission_control::AbortMission::ConstPtr& msg);
-  void queryMissionsCallback(const mission_control::QueryMissions::ConstPtr& msg);
-  void removeMissionsCallback(const mission_control::RemoveMissions::ConstPtr& msg);
-  void reportFaultCallback(const health_monitor::ReportFault::ConstPtr& msg);
+  void spin();
 
 private:
-  void registerBehaviorActions();
+  void reportOn(const Mission& mission);
+  void update(const ros::TimerEvent& ev);
 
-  ros::NodeHandle pnh;
-  // Vars holding runtime params
-  double reportExecuteMissionStateRate;
-  double reportHeartbeatRate;
-  double executeMissionAsynchronousRate;
-  double maxCtrlFinAngle;
+  void reportHeartbeat(const ros::TimerEvent& ev);
 
-  int currentMissionId;
-  int MissionIdCounter;
-  int missionState;
+  void loadMissionCallback(const LoadMission& msg);
+  void executeMissionCallback(const ExecuteMission& msg);
+  void abortMissionCallback(const AbortMission& msg);
+  void queryMissionsCallback(const QueryMissions& msg);
+  void removeMissionsCallback(const RemoveMissions& msg);
 
-  std::unordered_map<int, std::unique_ptr<Mission>> m_mission_map;
-  uint64_t heartbeat_sequence_id;
-  BT::BehaviorTreeFactory missionFactory_;
+  void faultCallback(const health_monitor::ReportFault& msg);
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle pnh_;
+
+  ros::Subscriber fault_sub_;
+
+  ros::Subscriber load_mission_sub_;
+  ros::Subscriber execute_mission_sub_;
+  ros::Subscriber abort_mission_sub_;
+  ros::Subscriber query_mission_sub_;
+  ros::Subscriber remove_mission_sub_;
+
+  ros::Publisher report_mission_load_state_pub_;
+  ros::Publisher report_mission_execute_state_pub_;
+  ros::Publisher report_missions_pub_;
+  ros::Publisher report_heartbeat_pub_;
+
+  ros::Timer heartbeat_timer_;
+  ros::Timer update_timer_;
+
+  uint64_t system_fault_ids_{0};
+  uint64_t heartbeat_sequence_id_{0};
+
+  std::shared_ptr<Mission> current_mission_;
+  std::unordered_map<int, std::shared_ptr<Mission>> mission_map_;
+  ReportExecuteMissionState last_mission_state_report_;
 };
+
+}  // namespace mission_control
 
 #endif  // MISSION_CONTROL_MISSION_CONTROL_H

--- a/mission_control/launch/mission_control.launch
+++ b/mission_control/launch/mission_control.launch
@@ -1,12 +1,11 @@
 <launch>
     <!-- mission control -->
-    <arg name="report_execute_mission_state_rate" default="1.0"/>
-    <arg name="report_heart_beat_rate" default="1.0"/>
-    <arg name="execute_mission_asynchronous_rate" default="0.1"/>
-    
+    <arg name="heartbeat_rate" default="1.0"/>
+    <arg name="update_rate" default="10.0"/>
+
     <node pkg="mission_control" type="mission_control_node" name="mission_control_node" output="screen">
-        <param name="report_execute_mission_state_rate" type="double" value="$(arg report_execute_mission_state_rate)"/>
-        <param name="report_heart_beat_rate" type="double" value="$(arg report_heart_beat_rate)"/>
-        <param name="execute_mission_asynchronous_rate" type="double" value="$(arg execute_mission_asynchronous_rate)"/>
+        <remap from="faults" to="/health_monitor/report_fault"/>
+        <param name="update_rate" type="double" value="$(arg update_rate)"/>
+        <param name="heartbeat_rate" type="double" value="$(arg heartbeat_rate)"/>
     </node>
 </launch>

--- a/mission_control/src/behaviors/attitude_servo.cpp
+++ b/mission_control/src/behaviors/attitude_servo.cpp
@@ -57,6 +57,7 @@ AttitudeServoBehavior::AttitudeServoBehavior(const std::string& name,
   pitchTolerance_ = 0;
   yawTolerance_ = 0;
 
+  // TODO(hidmic): revisit
   getInput<double>("roll", roll_);
   if (roll_ != 0.0) rollEnable_ = true;
 

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -42,7 +42,7 @@ using BT::NodeStatus;
 using BT::Tree;
 using mission_control::Mission;
 
-Mission::Mission(BT::Tree && missionTree) : tree_(std::move(missionTree))
+Mission::Mission(BT::Tree&& missionTree) : tree_(std::move(missionTree))
 {
   description_ = tree_.rootNode()->name();
   behaviorStatus_ = BT::NodeStatus::IDLE;
@@ -72,12 +72,10 @@ BT::NodeStatus Mission::getStatus() { return behaviorStatus_; }
 
 std::string Mission::getCurrentMissionDescription() { return description_; }
 
-BT::NodeStatus Mission::Continue()
+void Mission::Continue()
 {
   if (behaviorStatus_ == BT::NodeStatus::IDLE || behaviorStatus_ == BT::NodeStatus::RUNNING)
   {
     behaviorStatus_ = tree_.tickRoot();
   }
-
-  return behaviorStatus_;
 }

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -1,4 +1,3 @@
-
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
@@ -36,46 +35,183 @@
 // Original version: Christopher Scianna Christopher.Scianna@us.QinetiQ.com
 #include "mission_control/mission.h"
 
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "mission_control/behaviors/waypoint.h"
+#include "mission_control/behaviors/fixed_rudder.h"
+#include "mission_control/behaviors/depth_heading.h"
+#include "mission_control/behaviors/attitude_servo.h"
+
 #include <string>
 
-using BT::NodeStatus;
-using BT::Tree;
-using mission_control::Mission;
 
-Mission::Mission(BT::Tree&& missionTree) : tree_(std::move(missionTree))
+namespace mission_control
 {
-  description_ = tree_.rootNode()->name();
-  behaviorStatus_ = BT::NodeStatus::IDLE;
+
+namespace
+{
+
+class MissionBehaviorTreeFactory : public BT::BehaviorTreeFactory
+{
+ public:
+  static MissionBehaviorTreeFactory& instance()
+  {
+    static MissionBehaviorTreeFactory factory;
+    return factory;
+  }
+ private:
+  MissionBehaviorTreeFactory()
+  {
+    // TODO(hidmic): load behavior classes from ROS plugins
+    this->registerNodeType<mission_control::GoToWaypoint>("GoToWaypoint");
+    this->registerNodeType<mission_control::MoveWithFixedRudder>("MoveWithFixedRudder");
+    this->registerNodeType<mission_control::DepthHeadingBehavior>("DepthHeadingBehavior");
+    this->registerNodeType<mission_control::AttitudeServoBehavior>("AttitudeServoBehavior");
+  }
+};
+
+}  // namespace
+
+int Mission::id_sequence_ = 0;
+
+Mission::Mission(BT::Tree&& behavior_tree)  // NOLINT
+    : main_behavior_tree_(std::move(behavior_tree)),
+      status_(Mission::Status::READY),
+      id_(++id_sequence_)
+{
+  // TODO(hidmic): fetch pitch angle from blackboard
+  static constexpr char text[] = R"(
+<root main_tree_to_execute="Go to the surface" >
+    <BehaviorTree ID="Go to the surface">
+       <AttitudeServoBehavior name="Command thruster and fins"
+           roll="0.0" pitch="-0.3490658503988659" yaw="0.0" speed_knots="0.0"/>
+    </BehaviorTree>
+</root>
+)";
+
+  MissionBehaviorTreeFactory& factory =
+      MissionBehaviorTreeFactory::instance();
+  abort_behavior_tree_ = factory.createTreeFromText(text);
 }
 
-Mission::~Mission() {}
-
-std::unique_ptr<Mission> Mission::FromMissionDefinition(const std::string& missionFullPath,
-                                                        BT::BehaviorTreeFactory& missionFactory)
+namespace filesystem
 {
-  if (access(missionFullPath.c_str(), F_OK) != -1)
+
+bool exists(const std::string& path)
+{
+  struct stat tmp;
+  return stat(path.c_str(), &tmp) == 0;
+}
+
+}  // namespace filesystem
+
+std::unique_ptr<Mission> Mission::fromFile(const std::string& path)
+{
+  if (!filesystem::exists(path))
   {
-    return std::unique_ptr<Mission>(
-        new Mission(missionFactory.createTreeFromFile(missionFullPath)));
-  }
-  else
+    ROS_ERROR_STREAM("Cannot read mission definition from " << path);
     return nullptr;
-}
-
-void Mission::stop()
-{
-  tree_.haltTree();
-  behaviorStatus_ = BT::NodeStatus::IDLE;
-}
-
-BT::NodeStatus Mission::getStatus() { return behaviorStatus_; }
-
-std::string Mission::getCurrentMissionDescription() { return description_; }
-
-void Mission::Continue()
-{
-  if (behaviorStatus_ == BT::NodeStatus::IDLE || behaviorStatus_ == BT::NodeStatus::RUNNING)
-  {
-    behaviorStatus_ = tree_.tickRoot();
   }
+
+  MissionBehaviorTreeFactory& factory = MissionBehaviorTreeFactory::instance();
+  return std::unique_ptr<Mission>(new Mission(factory.createTreeFromFile(path)));
 }
+
+const std::string& Mission::description() const
+{
+  return main_behavior_tree_.rootNode()->name();
+}
+
+bool Mission::active() const
+{
+  return (status_ != Mission::Status::READY &&
+          status_ != Mission::Status::PREEMPTED &&
+          status_ != Mission::Status::COMPLETED &&
+          status_ != Mission::Status::ABORTED);
+}
+
+Mission& Mission::start()
+{
+  if (!active())
+  {
+    status_ = Mission::Status::PENDING;
+  }
+  return *this;
+}
+
+Mission& Mission::resume()
+{
+  switch (status_)
+  {
+    case Mission::Status::PENDING:
+    case Mission::Status::EXECUTING:
+      switch (main_behavior_tree_.tickRoot())
+      {
+        case BT::NodeStatus::RUNNING:
+          status_ = Mission::Status::EXECUTING;
+          break;
+        case BT::NodeStatus::SUCCESS:
+          status_ = Mission::Status::COMPLETED;
+          break;
+        case BT::NodeStatus::FAILURE:
+          status_ = Mission::Status::ABORTING;
+          break;
+      }
+      break;
+    case Mission::Status::ABORTING:
+      switch (abort_behavior_tree_.tickRoot())
+      {
+        case BT::NodeStatus::RUNNING:
+          status_ = Mission::Status::ABORTING;
+          break;
+        case BT::NodeStatus::SUCCESS:
+        case BT::NodeStatus::FAILURE:
+          status_ = Mission::Status::ABORTED;
+          break;
+      }
+      break;
+    default:
+      break;
+  }
+  return *this;
+}
+
+Mission& Mission::preempt()
+{
+  switch (status_)
+  {
+    case Mission::Status::PENDING:
+      status_ = Mission::Status::PREEMPTED;
+      break;
+    case Mission::Status::EXECUTING:
+      status_ = Mission::Status::PREEMPTED;
+      main_behavior_tree_.haltTree();
+      break;
+    case Mission::Status::ABORTING:
+      status_ = Mission::Status::PREEMPTED;
+      abort_behavior_tree_.haltTree();
+    default:
+      break;
+  }
+  return *this;
+}
+
+Mission& Mission::abort()
+{
+  switch (status_)
+  {
+    case Mission::Status::PENDING:
+      status_ = Mission::Status::ABORTED;
+      break;
+    case Mission::Status::EXECUTING:
+      status_ = Mission::Status::ABORTING;
+      main_behavior_tree_.haltTree();
+      break;
+    default:
+      break;
+  }
+  return *this;
+}
+
+}  // namespace mission_control

--- a/mission_control/src/mission_control.cpp
+++ b/mission_control/src/mission_control.cpp
@@ -38,284 +38,272 @@
 
 #include <string>
 
-MissionControlNode::MissionControlNode(ros::NodeHandle& h) : pnh(h)
+namespace mission_control
 {
-  heartbeat_sequence_id = 0;
-  last_state = Mission::State::READY;
-  reportExecuteMissionStateRate = 1.0;  // every 1 second
-  reportHeartbeatRate = 1.0;            // every 1 second
-  currentMissionId = 0;
-  MissionIdCounter = 0;
 
-  reportExecuteMissionStateRate = 1.0;
-  reportHeartbeatRate = 1.0;
-
+MissionControlNode::MissionControlNode() : nh_(), pnh_("~")
+{
   // Get runtime parameters
-  pnh.getParam("report_execute_mission_state_rate", reportExecuteMissionStateRate);
-  pnh.getParam("report_heart_beat_rate", reportHeartbeatRate);
-  pnh.getParam("execute_mission_asynchronous_rate", executeMissionAsynchronousRate);
+  double heartbeat_rate;
+  pnh_.param("heartbeat_rate", heartbeat_rate, 1.0);  // Hz
+  ROS_DEBUG_STREAM("heartbeat rate: " << heartbeat_rate);
 
-  pnh.param<double>("/fin_control/max_ctrl_fin_angle", maxCtrlFinAngle, 10.0);
+  double update_rate;
+  pnh_.param("update_rate", update_rate, 10.0);  // Hz
+  ROS_DEBUG_STREAM("update rate: " << update_rate);
 
-  ROS_DEBUG_STREAM("report executemissionstate rate: " << reportExecuteMissionStateRate);
-  ROS_DEBUG_STREAM("report heartbeat rate: " << reportHeartbeatRate);
+  // TODO(hidmic): give behaviors access to parameters via blackboard
+  // pnh.param<double>("/fin_control/max_ctrl_fin_angle", maxCtrlFinAngle, 10.0);
 
   // Subscribe to all topics
-  report_fault_sub = pnh.subscribe("/health_monitor/report_fault", 1,
-                                   &MissionControlNode::reportFaultCallback, this);
-  load_mission_sub =
-      pnh.subscribe("load_mission", 1, &MissionControlNode::loadMissionCallback, this);
-  execute_mission_sub =
-      pnh.subscribe("execute_mission", 1, &MissionControlNode::executeMissionCallback, this);
-  abort_mission_sub =
-      pnh.subscribe("abort_mission", 1, &MissionControlNode::abortMissionCallback, this);
-  query_mission_sub =
-      pnh.subscribe("query_missions", 1, &MissionControlNode::queryMissionsCallback, this);
-  remove_mission_sub =
-      pnh.subscribe("remove_missions", 1, &MissionControlNode::removeMissionsCallback, this);
+  fault_sub_ = nh_.subscribe("faults", 1, &MissionControlNode::faultCallback, this);
+
+  load_mission_sub_ =
+      pnh_.subscribe("load_mission", 1, &MissionControlNode::loadMissionCallback, this);
+  execute_mission_sub_ =
+      pnh_.subscribe("execute_mission", 1, &MissionControlNode::executeMissionCallback, this);
+  abort_mission_sub_ =
+      pnh_.subscribe("abort_mission", 1, &MissionControlNode::abortMissionCallback, this);
+  query_mission_sub_ =
+      pnh_.subscribe("query_missions", 1, &MissionControlNode::queryMissionsCallback, this);
+  remove_mission_sub_ =
+      pnh_.subscribe("remove_missions", 1, &MissionControlNode::removeMissionsCallback, this);
 
   // Advertise all topics and services
-  pub_report_mission_load_state =
-      pnh.advertise<mission_control::ReportLoadMissionState>("report_mission_load_state", 100);
-  pub_report_mission_execute_state = pnh.advertise<mission_control::ReportExecuteMissionState>(
-      "report_mission_execute_state", 100);
-  pub_report_missions = pnh.advertise<mission_control::ReportMissions>("report_missions", 100);
-  pub_report_heartbeat = pnh.advertise<mission_control::ReportHeartbeat>("report_heartbeat", 100);
-  pub_activate_manual_control = pnh.advertise<jaus_ros_bridge::ActivateManualControl>(
-      "/jaus_ros_bridge/activate_manual_control", 1);
+  report_mission_load_state_pub_ =
+      pnh_.advertise<ReportLoadMissionState>("report_mission_load_state", 100);
+  report_mission_execute_state_pub_ =
+      pnh_.advertise<ReportExecuteMissionState>("report_mission_execute_state", 100);
+  report_missions_pub_ = pnh_.advertise<ReportMissions>("report_missions", 100);
+  report_heartbeat_pub_ = pnh_.advertise<ReportHeartbeat>("report_heartbeat", 100);
 
-  pub_attitude_servo = pnh.advertise<mission_control::AttitudeServo>("/mngr/attitude_servo", 1);
+  heartbeat_timer_ = pnh_.createTimer(
+      ros::Duration(1.0 / heartbeat_rate),
+      &MissionControlNode::reportHeartbeat, this);
 
-  reportExecuteMissionStateTimer =
-      pnh.createTimer(ros::Duration(reportExecuteMissionStateRate),
-                      &MissionControlNode::reportExecuteMissionState, this);
-  reportHeartbeatTimer = pnh.createTimer(ros::Duration(reportHeartbeatRate),
-                                         &MissionControlNode::reportHeartbeat, this);
+  update_timer_ = pnh_.createTimer(
+      ros::Duration(1.0 / update_rate),
+      &MissionControlNode::update, this);
 
-  executeMissionTimer = pnh.createTimer(ros::Duration(executeMissionAsynchronousRate),
-                                        &MissionControlNode::executeMissionT, this);
-  executeMissionTimer.stop();
-  missionState = mission_control::ReportExecuteMissionState::PAUSED;
-  registerBehaviorActions();
+  last_mission_state_report_.mission_id = 0;
 }
 
-MissionControlNode::~MissionControlNode() {}
-
-int MissionControlNode::loadMissionFile(std::string mission_full_path)
+void MissionControlNode::reportHeartbeat(const ros::TimerEvent&)
 {
-  std::unique_ptr<Mission> newMission =
-      Mission::FromMissionDefinition(mission_full_path, missionFactory_);
+  ReportHeartbeat msg;
+  msg.header.stamp = ros::Time::now();
+  msg.seq_id = heartbeat_sequence_id_++;
+  report_heartbeat_pub_.publish(msg);
+}
 
-  if (newMission)
+namespace
+{
+
+using ReportExecuteMissionStateType =
+    ReportExecuteMissionState::_execute_mission_state_type;
+
+const char *to_string(ReportExecuteMissionStateType state)
+{
+  switch (state)
   {
-    MissionIdCounter++;
-    m_mission_map[MissionIdCounter] = std::move(newMission);
-    return 0;
-  }
-  else
-    return -1;
-}
-
-int MissionControlNode::abortMission(int missionId)
-{
-  executeMissionTimer.stop();
-  ROS_ERROR_STREAM("Aborting Mission " << currentMissionId);
-
-  // fins to surface and thruster RPM = 0
-  mission_control::AttitudeServo msg;
-  msg.roll = 0;
-  msg.pitch = -maxCtrlFinAngle;
-  msg.yaw = 0;
-  msg.speed_knots = 0;
-  msg.ena_mask = 15;
-
-  pub_attitude_servo.publish(msg);
-}
-
-void MissionControlNode::reportHeartbeat(const ros::TimerEvent& timer)
-{
-  ReportHeartbeat outmsg;
-  outmsg.header.stamp = ros::Time::now();
-  outmsg.seq_id = heartbeat_sequence_id++;
-  pub_report_heartbeat.publish(outmsg);
-}
-
-void MissionControlNode::executeMissionT(const ros::TimerEvent& timer)
-{
-  switch (missionState)
-  {
-    case mission_control::ReportExecuteMissionState::PAUSED:
-      m_mission_map[currentMissionId]->Continue();
-      break;
-    case mission_control::ReportExecuteMissionState::EXECUTING:
-      m_mission_map[currentMissionId]->Continue();
-      break;
-    case mission_control::ReportExecuteMissionState::COMPLETE:
-      executeMissionTimer.stop();
-      break;
-    case mission_control::ReportExecuteMissionState::ABORTING:
-      abortMission(currentMissionId);
-      break;
-  }
-
-  switch (m_mission_map[currentMissionId]->getStatus())
-  {
-    case BT::NodeStatus::IDLE:
-      missionState = mission_control::ReportExecuteMissionState::PAUSED;
-      break;
-    case BT::NodeStatus::RUNNING:
-      missionState = mission_control::ReportExecuteMissionState::EXECUTING;
-      break;
-    case BT::NodeStatus::SUCCESS:
-      missionState = mission_control::ReportExecuteMissionState::COMPLETE;
-      break;
-    case BT::NodeStatus::FAILURE:
-      missionState = mission_control::ReportExecuteMissionState::ABORTING;
-      break;
+    case ReportExecuteMissionState::ERROR:
+      return "ERROR";
+    case ReportExecuteMissionState::ABORTING:
+      return "ABORTING";
+    case ReportExecuteMissionState::COMPLETE:
+      return "COMPLETE";
+    case ReportExecuteMissionState::PAUSED:
+      return "PAUSED";
+    case ReportExecuteMissionState::EXECUTING:
+      return "EXECUTING";
   }
 }
 
-void MissionControlNode::reportExecuteMissionState(const ros::TimerEvent& timer)
+}  // namespace
+
+void MissionControlNode::reportOn(const Mission& mission)
 {
-  if ((currentMissionId != 0) && (m_mission_map.size() > 0) &&
-      (m_mission_map.count(currentMissionId) > 0))
+  ReportExecuteMissionState msg;
+  msg.header.stamp = ros::Time::now();
+  msg.mission_id = mission.id();
+
+  // TODO(hidmic): revisit state enum in mission control ROS interface
+  switch (mission.status())
   {
-    ReportExecuteMissionState outmsg;
-    outmsg.execute_mission_state = missionState;
-    outmsg.current_behavior_name = m_mission_map[currentMissionId]->getCurrentMissionDescription();
-    outmsg.mission_id = currentMissionId;
-    outmsg.header.stamp = ros::Time::now();
-    pub_report_mission_execute_state.publish(outmsg);
+    case Mission::Status::PENDING:
+    case Mission::Status::EXECUTING:
+      msg.execute_mission_state = ReportExecuteMissionState::EXECUTING;
+      msg.current_behavior_name = "";  // TODO(hidmic): populate
+      break;
+    case Mission::Status::ABORTING:
+      msg.execute_mission_state = ReportExecuteMissionState::ABORTING;
+      msg.current_behavior_name = "";  // TODO(hidmic): populate
+      break;
+    case Mission::Status::COMPLETED:
+    case Mission::Status::PREEMPTED:
+    case Mission::Status::ABORTED:
+      msg.execute_mission_state = ReportExecuteMissionState::COMPLETE;
+      break;
+    default:
+      break;
+  }
+
+  if (last_mission_state_report_.mission_id != msg.mission_id ||
+      last_mission_state_report_.execute_mission_state != msg.execute_mission_state)
+  {
+    ROS_INFO_STREAM("Mission [" << mission.id() << "] " <<
+                    to_string(msg.execute_mission_state));
+    report_mission_execute_state_pub_.publish(msg);
+    last_mission_state_report_ = msg;
   }
 }
 
-void MissionControlNode::loadMissionCallback(const mission_control::LoadMission::ConstPtr& msg)
+void MissionControlNode::spin()
 {
-  ROS_DEBUG_STREAM("loadMissionCallback - just received mission file "
-                   << msg->mission_file_full_path.c_str());
+  ros::spin();
+}
 
-  int retval = loadMissionFile(msg->mission_file_full_path);
+void MissionControlNode::update(const ros::TimerEvent&)
+{
+  if (current_mission_)
+  {
+    reportOn(current_mission_->resume());
+
+    if (!current_mission_->active())
+    {
+      current_mission_.reset();
+    }
+  }
+}
+
+void MissionControlNode::loadMissionCallback(const mission_control::LoadMission& msg)
+{
+  ROS_DEBUG_STREAM(
+      "loadMissionCallback - just received mission file " <<
+      msg.mission_file_full_path);
+
+  std::unique_ptr<Mission> mission =
+      Mission::fromFile(msg.mission_file_full_path);
 
   ReportLoadMissionState outmsg;
-  if (retval == -1)
-  {
-    outmsg.load_state = ReportLoadMissionState::FAILED;
-    outmsg.mission_id = 0;
-    ROS_ERROR_STREAM("loadMissionCallback - FAILED to parse mission file "
-                     << msg->mission_file_full_path.c_str());
-  }
-  else
-  {
-    outmsg.load_state = ReportLoadMissionState::SUCCESS;
-    outmsg.mission_id = MissionIdCounter;
-    ROS_DEBUG_STREAM("loadMissionCallback - SUCCESSFULLY parsed mission file "
-                     << msg->mission_file_full_path.c_str());
-  }
-
   outmsg.header.stamp = ros::Time::now();
-  pub_report_mission_load_state.publish(outmsg);
-}
+  if (mission)
+  {
+    ROS_DEBUG_STREAM(
+        "loadMissionCallback - SUCCESSFULLY parsed mission file " <<
+        msg.mission_file_full_path);
+    int mission_id = mission->id();
+    mission_map_[mission_id] = std::move(mission);
 
-void MissionControlNode::executeMissionCallback(
-    const mission_control::ExecuteMission::ConstPtr& msg)
-{
-  if (currentMissionId > 0)
-  {
-    BT::NodeStatus behaviorStatus = m_mission_map[currentMissionId]->getStatus();
-    if ((behaviorStatus != BT::NodeStatus::IDLE) && (behaviorStatus != BT::NodeStatus::SUCCESS))
-    {
-      ROS_WARN_STREAM("There is a mission being executed - mission id["
-                      << currentMissionId
-                      << "] - Mission Status: " << m_mission_map[currentMissionId]->getStatus());
-      return;
-    }
-  }
-  if ((msg->mission_id > 0) && (m_mission_map.size() > 0) &&
-      (m_mission_map.count(msg->mission_id) > 0))
-  {
-    currentMissionId = msg->mission_id;
-    executeMissionTimer.start();
-    ROS_DEBUG_STREAM("executeMissionCallback - Executing mission id[" << currentMissionId << "]");
+    outmsg.mission_id = mission_id;
+    outmsg.load_state = ReportLoadMissionState::SUCCESS;
   }
   else
   {
-    ROS_ERROR_STREAM("Error - Wrong Mission Number. "
-                     << "Mission Number: " << msg->mission_id);
+    ROS_DEBUG_STREAM(
+        "loadMissionCallback - FAILED to parse mission file " <<
+        msg.mission_file_full_path);
+    outmsg.load_state = ReportLoadMissionState::FAILED;
   }
+  report_mission_load_state_pub_.publish(outmsg);
 }
 
-void MissionControlNode::abortMissionCallback(const mission_control::AbortMission::ConstPtr& msg)
+void MissionControlNode::executeMissionCallback(const mission_control::ExecuteMission& msg)
 {
-  executeMissionTimer.stop();
-  if (msg->mission_id != currentMissionId)
+  if (system_fault_ids_)
+  {
+    ROS_ERROR("No mission can be executed in a faulty system, ignoring execute request");
+    return;
+  }
+
+  if (mission_map_.count(msg.mission_id) == 0)
+  {
+    ROS_ERROR_STREAM("No mission [" << msg.mission_id << "] was found, ignoring execute request");
+    return;
+  }
+
+  if (current_mission_)
+  {
+    ROS_DEBUG_STREAM(
+        "executeMissionCallback - Preempting mission [" << current_mission_->id() << "]");
+
+    reportOn(current_mission_->preempt());
+  }
+
+  current_mission_ = mission_map_[msg.mission_id];
+
+  ROS_DEBUG_STREAM("executeMissionCallback - Executing mission [" << current_mission_->id() << "]");
+
+  reportOn(current_mission_->start());
+}
+
+void MissionControlNode::abortMissionCallback(const mission_control::AbortMission& msg)
+{
+  if (!current_mission_)
+  {
+    ROS_WARN("No mission to abort, ignoring abort request");
+    return;
+  }
+
+  if (current_mission_->id() != msg.mission_id)
   {
     ROS_WARN_STREAM(
-        "The mission being executed is different from the requested to abort"
-        "Mission Id: "
-        << currentMissionId);
+        "Mission [" << msg.mission_id << "] is not currently executing, ignoring request");
+    return;
   }
-  else
-  {
-    if (currentMissionId > 0)
-    {
-      ROS_DEBUG_STREAM("abortMissionCallback from Jaus Ros Bridge - Stopping mission id "
-                       << msg->mission_id);
-      executeMissionTimer.stop();
-      missionState = mission_control::ReportExecuteMissionState::PAUSED;
-    }
-  }
+
+  ROS_DEBUG_STREAM("abortMissionCallback - Stopping mission [" << current_mission_->id() << "]");
+
+  reportOn(current_mission_->abort());
 }
 
-void MissionControlNode::queryMissionsCallback(const mission_control::QueryMissions::ConstPtr& msg)
+void MissionControlNode::queryMissionsCallback(const mission_control::QueryMissions&)
 {
-  ReportMissions outmsg;
-  MissionData data;
+  mission_control::ReportMissions msg;
+  msg.header.stamp = ros::Time::now();
 
   ROS_DEBUG_STREAM("queryMissionsCallback - Reporting these missions");
-  for (const auto& entry : m_mission_map)
+  for (const auto& entry : mission_map_)
   {
-    data.mission_id = entry.first;
-    data.mission_description = entry.second->getCurrentMissionDescription();
-    outmsg.missions.push_back(data);
-    ROS_DEBUG_STREAM("Mission Id: " << data.mission_id
-                                    << " Description: " << data.mission_description.c_str());
+    const Mission* mission = entry.second.get();
+    mission_control::MissionData data;
+    data.mission_id = mission->id();
+    data.mission_description = mission->description();
+    ROS_DEBUG_STREAM("Mission Id: " << data.mission_id << " " <<
+                     "Description: " << data.mission_description);
+    msg.missions.push_back(data);
   }
-  outmsg.header.stamp = ros::Time::now();
-  pub_report_missions.publish(outmsg);
+
+  report_missions_pub_.publish(msg);
 }
 
-void MissionControlNode::removeMissionsCallback(
-    const mission_control::RemoveMissions::ConstPtr& msg)
+void MissionControlNode::removeMissionsCallback(const mission_control::RemoveMissions&)
 {
-  if (m_mission_map.size() > 0)
+  ROS_DEBUG_STREAM("removeMissionsCallback - Removing missions");
+  mission_map_.clear();
+}
+
+void MissionControlNode::faultCallback(const health_monitor::ReportFault& msg)
+{
+  if (system_fault_ids_ != msg.fault_id)
   {
-    if (currentMissionId != 0)
+    // TODO(hidmic): handle non critical faults
+    if (msg.fault_id != 0)
     {
-      executeMissionTimer.stop();
-      m_mission_map[currentMissionId]->stop();
-      currentMissionId = 0;
-      MissionIdCounter = 0;
+      ROS_ERROR_STREAM("Got system faults " << msg.fault_id);
+
+      if (current_mission_)
+      {
+        ROS_WARN_STREAM("Aborting mission [" << current_mission_->id() << "]");
+        reportOn(current_mission_->abort());
+      }
     }
-    ROS_DEBUG_STREAM("removeMissionsCallback - Removing missions");
-    m_mission_map.clear();
+    else
+    {
+      ROS_INFO("System faults cleared!");
+    }
+    system_fault_ids_ = msg.fault_id;
   }
 }
 
-void MissionControlNode::reportFaultCallback(const health_monitor::ReportFault::ConstPtr& msg)
-{
-  if (msg->fault_id != 0)
-  {
-    ROS_ERROR_STREAM("Fault Detected by health monitor[" << msg->fault_id << "] aborting mission");
-    executeMissionTimer.stop();
-    abortMission(currentMissionId);
-    missionState = mission_control::ReportExecuteMissionState::ABORTING;
-  }
-}
-
-void MissionControlNode::registerBehaviorActions()
-{
-  missionFactory_.registerNodeType<mission_control::GoToWaypoint>("GoToWaypoint");
-  missionFactory_.registerNodeType<mission_control::MoveWithFixedRudder>("MoveWithFixedRudder");
-  missionFactory_.registerNodeType<mission_control::DepthHeadingBehavior>("DepthHeadingBehavior");
-  missionFactory_.registerNodeType<mission_control::AttitudeServoBehavior>("AttitudeServoBehavior");
-}
+}  // namespace mission_control

--- a/mission_control/src/mission_control_main.cpp
+++ b/mission_control/src/mission_control_main.cpp
@@ -46,18 +46,15 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "mission_control_node");
 
-  ros::NodeHandle nh("~");
-  ROS_INFO("Starting Mission control node Version: [%s]", NODE_VERSION);
+  ros::NodeHandle nh;
+  ROS_INFO("Starting mission control version: [%s]", NODE_VERSION);
   nh.setParam("/version_numbers/mission_control_node", NODE_VERSION);
 
-  MissionControlNode mcn(nh);
-  ros::Rate loop_rate(10);
-  while (ros::ok())
-  {
-    ros::spinOnce();
-    loop_rate.sleep();
-  }
-  ROS_INFO("Mission control shutting down");
+  mission_control::MissionControlNode node;
+
+  node.spin();
+
+  ROS_INFO("Shutting down mission control");
 
   return 0;
 }

--- a/mission_control/test/test_behavior_object.cpp
+++ b/mission_control/test/test_behavior_object.cpp
@@ -1,17 +1,47 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
 
 #include <behaviortree_cpp_v3/basic_types.h>
 #include <behaviortree_cpp_v3/behavior_tree.h>
 #include <behaviortree_cpp_v3/bt_factory.h>
 #include <gtest/gtest.h>
-#include <stdlib.h>
 
-#include <iostream>
+#include <string>
 
-#include "../include/mission_control/behavior.h"
+#include "mission_control/behavior.h"
 
-using namespace mission_control;
-
-class DummyBehavior : public Behavior
+class DummyBehavior : public mission_control::Behavior
 {
  public:
   DummyBehavior(const std::string& name, const BT::NodeConfiguration& config)
@@ -67,3 +97,4 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+

--- a/mission_control/test/test_behavior_object.cpp
+++ b/mission_control/test/test_behavior_object.cpp
@@ -52,23 +52,6 @@ GTEST_TEST(BehaviorTest, TestIfBehaviorStopsAfterHalt)
   ASSERT_TRUE(dummyBehavior.isHalted());
 }
 
-GTEST_TEST(BehaviorTest, TestIfBehaviorDoesntChangeStatusToIdleAfterSuccess)
-{
-  BT::NodeConfiguration nodeConfig;
-  DummyBehavior dummyBehavior("dummy", nodeConfig);
-  dummyBehavior.changeStatus(BT::NodeStatus::SUCCESS);
-  dummyBehavior.tick();
-  ASSERT_EQ(dummyBehavior.tick(), BT::NodeStatus::SUCCESS);
-}
-
-GTEST_TEST(BehaviorTest, TestIfBehaviorDontChangeStatusOnTickIfFailure)
-{
-  BT::NodeConfiguration nodeConfig;
-  DummyBehavior dummyBehavior("dummy", nodeConfig);
-  dummyBehavior.changeStatus(BT::NodeStatus::FAILURE);
-  ASSERT_EQ(dummyBehavior.tick(), BT::NodeStatus::FAILURE);
-}
-
 GTEST_TEST(BehaviorTest, TestIfBehaviorTickMultipleTimes)
 {
   BT::NodeConfiguration nodeConfig;

--- a/mission_control/test/test_files/test_missions/mission.xml
+++ b/mission_control/test/test_files/test_missions/mission.xml
@@ -4,7 +4,7 @@
 
      <BehaviorTree ID="MainTree">
         <Sequence name="mission test">
-            <GoToWaypoint     depth="1.0" altitude="2.0" latitude="3.0" longitude="4.0" wp_radius="5.0" speed_knots="6.0" time_out="5"/>
+            <MoveWithFixedRudder     depth="1.0" rudder="2.0" speed_knots="3.0" behavior_time="15.0" rudder_tol="5.0" depth_tol="6.0" altitude_tol="7.0"/>
         </Sequence>
      </BehaviorTree>
 

--- a/mission_control/test/test_if_mission_control_aborts_when_health_monitor_reports_fault.py
+++ b/mission_control/test/test_if_mission_control_aborts_when_health_monitor_reports_fault.py
@@ -38,34 +38,24 @@ import unittest
 import rosnode
 import rospy
 import rostest
-from mission_control.msg import LoadMission
-from mission_control.msg import ExecuteMission
 from mission_control.msg import ReportExecuteMissionState
-from mission_control.msg import ReportLoadMissionState
 from health_monitor.msg import ReportFault
-from jaus_ros_bridge.msg import ActivateManualControl
-
-
-def wait_for(predicate, period=1):
-    while not rospy.is_shutdown():
-        result = predicate()
-        if result:
-            return result
-        rospy.sleep(period)
-    return predicate()
+from mission_control.msg import AttitudeServo
+from mission_interface import MissionInterface
+from mission_interface import wait_for
 
 
 class TestMissionControlAbortsWhenHealthMonitorReportsFault(unittest.TestCase):
-    """ 
-        Simulate error message sent by health monitor and checks 
+    """
+        Simulate error message sent by health monitor and checks
         if the mission control publishes the abort status.
         The steps int the involved are:
             1)  Load a mission
             2)  Execute the Mission
             3)  Simulate an error sent by health monitor
             4)  check if the mission control abort the mission
-                a) Stop the current behavior
-                b) Send manual control command to autopilot
+                a) Receive Aborting State
+                b) Set the fins to surface and Thruster velocity to 0 RPM
     """
 
     @classmethod
@@ -73,81 +63,54 @@ class TestMissionControlAbortsWhenHealthMonitorReportsFault(unittest.TestCase):
         rospy.init_node('test_mission_control_aborts_procedure')
 
     def setUp(self):
-        self.dir_path = os.path.dirname(
-            os.path.abspath(__file__)) + '/test_files/'
-        self.mission_to_load = LoadMission()
-        self.mission_to_load.mission_file_full_path = self.dir_path + \
-            "test_missions/mission.xml"
-        self.mission_to_execute = ExecuteMission()
-        self.mission_to_execute.mission_id = 1
+        self.attitude_servo_goal = AttitudeServo()
+        self.mission = MissionInterface()
         self.simulate_error_code = ReportFault()
-        self.simulate_error_code.fault_id = ReportFault.PAYLOAD_ERROR
-        self.mission_load_state = ReportLoadMissionState()
-        self.report_execute_mission = ReportExecuteMissionState()
-        self.activate_manual_control = False
+        self.simulate_error_code.fault_id = ReportFault.AUTOPILOT_NODE_DIED
+        self.attitude_servo_aborting_goal = AttitudeServo()
 
-        # Subscribers
-        self.exec_state_sub = rospy.Subscriber('/mission_control_node/report_mission_execute_state',
-                                               ReportExecuteMissionState, self.callback_mission_execute_state)
+        self.attitude_servo_msg = rospy.Subscriber(
+            '/mngr/attitude_servo',
+            AttitudeServo,
+            self.attitude_servo_callback)
 
-        self.load_state_sub = rospy.Subscriber('/mission_control_node/report_mission_load_state',
-                                               ReportLoadMissionState, self.callback_mission_load_state)
+        self.simulated_health_monitor_pub = rospy.Publisher(
+            '/health_monitor/report_fault',
+            ReportFault, queue_size=1)
 
-        self.activate_manual_control_sub = rospy.Subscriber('/jaus_ros_bridge/activate_manual_control',
-                                                            ActivateManualControl, self.callback_activate_manual_control)
-
-        #   Publisher
-
-        self.simulated_mission_control_load_mission_pub = rospy.Publisher('/mission_control_node/load_mission',
-                                                                          LoadMission, latch=True, queue_size=1)
-
-        self.simulated_mission_control_execute_mission_pub = rospy.Publisher(
-            '/mission_control_node/execute_mission', ExecuteMission, latch=True, queue_size=1)
-
-        self.simulated_health_monitor_pub = rospy.Publisher('/health_monitor/report_fault',
-                                                            ReportFault, queue_size=1)
-
-    def callback_mission_execute_state(self, msg):
-        self.report_execute_mission = msg
-
-    def callback_mission_load_state(self, msg):
-        self.mission_load_state = msg.load_state
-
-    def callback_activate_manual_control(self, msg):
-        self.activate_manual_control = msg.activate_manual_control
+    def attitude_servo_callback(self, msg):
+        self.attitude_servo_aborting_goal = msg
 
     def test_mission_control_aborts_if_health_monitor_reports_fault(self):
+        self.mission.load_mission('mission.xml')
+        self.mission.execute_mission()
 
-        # Load Mission
-        self.simulated_mission_control_load_mission_pub.publish(
-            self.mission_to_load)
-
-        def load_valid_mission():
-            return self.mission_load_state == ReportLoadMissionState.SUCCESS
-        self.assertTrue(wait_for(load_valid_mission),
-                        msg='Error Loading mission')
-
-        # Execute Mission and check if the mission control reports status
-        self.simulated_mission_control_execute_mission_pub.publish(
-            self.mission_to_execute)
-
-        def success_mission_status_is_reported():
-            return self.report_execute_mission.execute_mission_state == ReportExecuteMissionState.EXECUTING
-        self.assertTrue(wait_for(success_mission_status_is_reported),
-                        msg='Mission control must report SUCCESS')
+        def executing_mission_status_is_reported():
+            return self.mission.execute_mission_state == ReportExecuteMissionState.EXECUTING
+        self.assertTrue(wait_for(executing_mission_status_is_reported),
+                        msg='Mission control must report EXECUTING')
 
         # Simulate the health monitor publishing the fault code
         self.simulated_health_monitor_pub.publish(self.simulate_error_code)
 
-        def abort_mission_status_is_reported():
-            return self.report_execute_mission.execute_mission_state == ReportExecuteMissionState.PAUSED
-        self.assertTrue(wait_for(abort_mission_status_is_reported),
-                        msg='Mission control must report STOP/ABORTING')
+        def aborting_mission_status_is_reported():
+            return self.mission.execute_mission_state == ReportExecuteMissionState.ABORTING
+        self.assertTrue(wait_for(aborting_mission_status_is_reported),
+                        msg='Mission control must report ABORTING')
 
-        def abort_mission_change_autopilot_to_manual_control():
-            return self.activate_manual_control
-        self.assertTrue(wait_for(abort_mission_change_autopilot_to_manual_control),
-                        msg='Mission control must send command to autopilot control for being manual')
+        # Check if the behavior publishes the attitude servo msg to
+        # set the fins to surface and velocity to 0 RPM
+        maxCtrlFinAngle = rospy.get_param('/fin_control/max_ctrl_fin_angle')
+
+        def attitude_servo_aborting_goals_are_set():
+            return (self.attitude_servo_aborting_goal.roll == 0.0 and
+                    self.attitude_servo_aborting_goal.pitch == -maxCtrlFinAngle and
+                    self.attitude_servo_aborting_goal.yaw == 0.0 and
+                    self.attitude_servo_aborting_goal.speed_knots == 0.0 and
+                    self.attitude_servo_aborting_goal.ena_mask == 15)
+        self.assertTrue(wait_for(attitude_servo_aborting_goals_are_set),
+                        msg='Mission control must publish goals')
+
 
 if __name__ == "__main__":
     rostest.rosrun('mission_control', 'mission_control_aborts_when_health_monitor_reports_fault',

--- a/mission_control/test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test
+++ b/mission_control/test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test
@@ -1,5 +1,6 @@
 <launch>
   <include file="$(find mission_control)/launch/mission_control.launch" />
+  <include file="$(find fin_control)/launch/fin_control.launch" />
 
   <!--
       Simulate error message sent by health monitor and checks 

--- a/mission_control/test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test
+++ b/mission_control/test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test
@@ -1,11 +1,11 @@
 <launch>
   <include file="$(find mission_control)/launch/mission_control.launch" />
-  <include file="$(find fin_control)/launch/fin_control.launch" />
+  <!-- <include file="$(find fin_control)/launch/fin_control.launch" /> -->
 
   <!--
-      Simulate error message sent by health monitor and checks 
-      if the mission control publishes the abort
+      Simulate error message sent by health monitor and checks if the mission control publishes the abort
   -->
-  <test test-name="test_mission_control_aborts_when_health_monitor_report_fault" pkg="mission_control" type="test_if_mission_control_aborts_when_health_monitor_reports_fault.py" time-limit="10.0" />
+  <test test-name="test_mission_control_aborts_when_health_monitor_report_fault" pkg="mission_control"
+        type="test_if_mission_control_aborts_when_health_monitor_reports_fault.py" time-limit="10.0" />
 
 </launch>

--- a/mission_control/test/test_mission_control_behaviors.test
+++ b/mission_control/test/test_mission_control_behaviors.test
@@ -8,7 +8,7 @@
         -   Attitude Servo
   -->
   
-  <test test-name="test_mission_control_fixed_rudder_action" pkg="mission_control" type="test_fixed_rudder_behavioral.py" time-limit="10.0" />
+  <test test-name="test_mission_control_fixed_rudder_action" pkg="mission_control" type="test_fixed_rudder_behavior.py" time-limit="10.0" />
   <test test-name="test_mission_control_attitude_servo_action" pkg="mission_control" type="test_attitude_servo_behavior.py" time-limit="10.0" />
   <test test-name="test_mission_control_depth_heading_action" pkg="mission_control" type="test_depth_heading_behavior.py" time-limit="10.0" />
 


### PR DESCRIPTION
# Description
This PR:
- Stop using jaus_ros_bridge manual control interface to abort missions. Now the aborting procedure sets the fins to surface and the thruster velocity to 0 RPM.
- If the Health monitor reports fault the mission control change its state to aborting. 
- Introduce a test that checks if the mission control publishes the msg to actuators.
- Change the mission->Continue(BT::tick method) from ReportExecuteMissionState to the executeMissionTimer.


Fixes # (issue)
After #88, it wasn't introduced the modification to the unit test. The behavior/action can't be ticket on SUCCESS or FAILURE state. This PR modify the test to reflect that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Tests are passing
- [x] Linter tests are passing

# How To Test

```sh
rostest mission_control test_if_mission_control_aborts_when_health_monitor_reports_fault.test
```