### PR TITLE
Add behavioral time_out test

### DIFF
--- a/mission_control/test/test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py
+++ b/mission_control/test/test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+"""
+import sys
+import os
+import unittest
+import rosnode
+import rospy
+import rostest
+from mission_control.msg import ReportExecuteMissionState
+from mission_control.msg import AttitudeServo
+from mission_interface import MissionInterface
+from mission_interface import wait_for
+
+
+class TestMissionControlAbortsWhenBehaviorReturnsTimeOutFailure(unittest.TestCase):
+    """
+        Test if the mission control aborts after the behavior returns Failure state.
+        The failure is produced because the mission time is greater than the time_out
+        mission behavior value
+        Args:
+            sys.argv[1] = Mission filename. It must be located in the test_mission folder.
+
+        The steps involved are:
+            1)  Load a mission
+            2)  Execute the mission
+            4)  Wait the mission control to publish a Failure state
+            5)  Wait the mission control to publish to actuators
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rospy.init_node('test_mission_control_aborts_procedure')
+
+    def setUp(self):
+        self.mission = MissionInterface()
+        self.attitude_servo_aborting_goal = AttitudeServo()
+
+        self.attitude_servo_msg = rospy.Subscriber(
+            '/mngr/attitude_servo',
+            AttitudeServo,
+            self.attitude_servo_callback)
+
+    def attitude_servo_callback(self, msg):
+        self.attitude_servo_aborting_goal = msg
+
+    def test_mission_control_aborts_if_health_monitor_reports_fault(self):
+        self.mission.load_mission(sys.argv[1])
+        self.mission.execute_mission()
+
+        # Wait for the mission returns time_out Failure
+        def aborting_mission_status_is_reported():
+            return self.mission.execute_mission_state == ReportExecuteMissionState.ABORTING
+        self.assertTrue(wait_for(aborting_mission_status_is_reported),
+                        msg='Mission control must report ABORTING')
+
+        # Check if the mission control publishes the attitude servo msg to
+        # set the fins to surface and velocity to 0 RPM
+        maxCtrlFinAngle = rospy.get_param('/fin_control/max_ctrl_fin_angle')
+
+        def attitude_servo_aborting_goals_are_set():
+            return (self.attitude_servo_aborting_goal.roll == 0.0 and
+                    self.attitude_servo_aborting_goal.pitch == -maxCtrlFinAngle and
+                    self.attitude_servo_aborting_goal.yaw == 0.0 and
+                    self.attitude_servo_aborting_goal.speed_knots == 0.0 and
+                    self.attitude_servo_aborting_goal.ena_mask == 15)
+        self.assertTrue(wait_for(attitude_servo_aborting_goals_are_set),
+                        msg='Mission control must publish goals')
+
+
+if __name__ == "__main__":
+    rostest.rosrun('mission_control', 'mission_control_aborts_when_health_monitor_reports_fault',
+                   TestMissionControlAbortsWhenBehaviorReturnsTimeOutFailure)

--- a/mission_control/test/test_if_mission_control_aborts_when_behavior_returns_time_out_failure.test
+++ b/mission_control/test/test_if_mission_control_aborts_when_behavior_returns_time_out_failure.test
@@ -1,0 +1,20 @@
+<launch>
+  <include file="$(find mission_control)/launch/mission_control.launch" />
+  <include file="$(find fin_control)/launch/fin_control.launch" />
+
+  <!--
+      Test if behaviors return Failure state after time out. 
+      The mission control must set fins to surface and Thruster velocity to 0 RPM.
+      The argument passed to the test is
+            - Mission filename to load and execute. It must be located in the test_files/test_mission folder.
+  -->
+
+  <test test-name="test_if_mission_control_aborts_when_attitude_servo_behavior_returns_time_out_failure" 
+        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py" 
+        time-limit="10.0" args="attitude_servo_mission_test.xml"/>
+
+  <test test-name="test_if_mission_control_aborts_when_depth_heading_behavior_returns_time_out_failure" 
+        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py" 
+        time-limit="10.0" args="depth_heading_mission_test.xml"/>
+
+</launch>


### PR DESCRIPTION
# Description
**This PR must be merged after #101.**

This PR introduces a test that checks if the mission control aborts when a behavior returns Failure because a time out.
The test checks if:
- The mission control changes ithe mission state to mission_control::ReportExecuteMissionState::ABORTING
- The mission control aborts the mission, e.g., send commands to actuators.

The mission tested are:
- Attitude Servo
- Depth Heading

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing - Roslint Pep8

# How To Test
This PR must be tested using #101
```sh
rostest mission_control test_if_mission_control_aborts_when_behavior_returns_time_out_failure.test --text
```
