### PR TITLE
Use AHRS fault codes for INS

### DIFF
--- a/ixblue_c3_ins/src/ixblue_c3_ins.cpp
+++ b/ixblue_c3_ins/src/ixblue_c3_ins.cpp
@@ -57,11 +57,11 @@
 
 #include <ros/ros.h>
 
-#include <diagnostic_tools/message_stagnation_check.h>
-#include <diagnostic_tools/periodic_message_status.h>
-
 #include <auv_interfaces/StateStamped.h>
 #include <auv_interfaces/helpers.h>
+#include <diagnostic_tools/message_stagnation_check.h>
+#include <diagnostic_tools/periodic_message_status.h>
+#include <health_monitor/ReportFault.h>
 
 #include "ixblue_c3_ins/c3_protocol.h"
 #include "ixblue_c3_ins/io_helpers.h"
@@ -122,8 +122,10 @@ ixBlueC3InsDriver::ixBlueC3InsDriver()
   {
     state_rate_check_params.max_acceptable_period(1.0 / min_rate);
   }
-  state_rate_check_params.abnormal_diagnostic(
-      qna::diagnostic_tools::Diagnostic::ERROR);
+  state_rate_check_params.abnormal_diagnostic({  // NOLINT
+      qna::diagnostic_tools::Diagnostic::ERROR,
+      health_monitor::ReportFault::AHRS_DATA_STALE
+  });  // NOLINT
   diagnostics_updater_.add(
       state_pub_.add_check<qna::diagnostic_tools::PeriodicMessageStatus>(
           "rate check", state_rate_check_params));
@@ -133,8 +135,10 @@ ixBlueC3InsDriver::ixBlueC3InsDriver()
   pnh_.param("absolute_steady_band", absolute_steady_band, 0.);
   pnh_.param("relative_steady_band", relative_steady_band, 0.);
   qna::diagnostic_tools::MessageStagnationCheckParams state_stagnation_check_params;
-  state_stagnation_check_params.stagnation_diagnostic(
-      qna::diagnostic_tools::Diagnostic::ERROR);
+  state_stagnation_check_params.stagnation_diagnostic({  // NOLINT
+      qna::diagnostic_tools::Diagnostic::ERROR,
+      health_monitor::ReportFault::AHRS_DATA_STAGNATED
+  });  // NOLINT
   diagnostics_updater_.add(
       state_pub_.add_check<qna::diagnostic_tools::MessageStagnationCheck>(
           "stagnation check",


### PR DESCRIPTION
# Description

As per offline discussion, this patch reuses AHRS fault codes in INS diagnostics.


## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing