### PR TITLE
Use AHRS_NODE_DIED fault when INS dies

### DIFF
--- a/health_monitor/include/health_monitor/health_monitor.h
+++ b/health_monitor/include/health_monitor/health_monitor.h
@@ -80,6 +80,7 @@ private:
         {
         {"payload_manager", health_monitor::ReportFault::PAYLOAD_NODE_DIED},
         {"vectornav", health_monitor::ReportFault::AHRS_NODE_DIED},
+        {"ixblue_c3_ins_node", health_monitor::ReportFault::AHRS_NODE_DIED},
         {"pressure_sensor", health_monitor::ReportFault::PRESSURE_NODE_DIED},
         {"mission_manager_node", health_monitor::ReportFault::MISSION_NODE_DIED},
         {"pose_estimator_node", health_monitor::ReportFault::POSE_NODE_DIED},


### PR DESCRIPTION
# Description

Precisely what the title say, as per offline discussion.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

1. Launch full system, including a `health_monitor` and INS:

```sh
roslaunch system_bringup full.launch use_ins:=true
```

2. Kill INS driver node:

```sh
kill -9 `rosnode info /ixblue_c3_ins_node | grep Pid | cut -d ' ' -f 2`
```

3. Verify an AHRS_NODE_DIED fault code is  set:
```sh
rostopic echo /health_monitor/report_fault
```
