### PR TITLE
Adapt mission control with auv interface

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -9,12 +9,11 @@ add_compile_options(-DTIXML_USE_STL)
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   actionlib_msgs
+  auv_interfaces
   behaviortree_cpp_v3
   health_monitor
   jaus_ros_bridge
   message_generation
-  pose_estimator
-  payload_manager
   roscpp
   roslint
   rospy
@@ -26,9 +25,7 @@ add_message_files(
   AttitudeServo.msg
   DepthHeading.msg
   FixedRudder.msg
-  Ping.msg
   Waypoint.msg
-  AltitudeHeading.msg
   LoadMission.msg
   ExecuteMission.msg
   ReportLoadMissionState.msg
@@ -43,14 +40,13 @@ add_message_files(
 
 generate_messages(
   DEPENDENCIES
-  pose_estimator
   payload_manager
   std_msgs
 )
 
 catkin_package(
  INCLUDE_DIRS include
- CATKIN_DEPENDS pose_estimator payload_manager health_monitor jaus_ros_bridge roscpp rospy std_msgs
+ CATKIN_DEPENDS auv_interfaces payload_manager health_monitor jaus_ros_bridge roscpp rospy std_msgs
 )
 
 ###########

--- a/mission_control/include/mission_control/behaviors/attitude_servo.h
+++ b/mission_control/include/mission_control/behaviors/attitude_servo.h
@@ -45,7 +45,7 @@
 
 #include "mission_control/AttitudeServo.h"
 #include "mission_control/behavior.h"
-#include "pose_estimator/CorrectedData.h"
+#include "auv_interfaces/StateStamped.h"
 
 namespace mission_control
 {
@@ -92,7 +92,7 @@ class AttitudeServoBehavior : public Behavior
   double pitchTolerance_;
   double yawTolerance_;
 
-  void correctedDataCallback(const pose_estimator::CorrectedData& data);
+  void stateDataCallback(const auv_interfaces::StateStamped& data);
   bool goalHasBeenPublished_;
   void publishGoalMsg();
   ros::Time behaviorStartTime_;

--- a/mission_control/include/mission_control/behaviors/depth_heading.h
+++ b/mission_control/include/mission_control/behaviors/depth_heading.h
@@ -45,54 +45,53 @@
 
 #include "mission_control/DepthHeading.h"
 #include "mission_control/behavior.h"
-#include "pose_estimator/CorrectedData.h"
+#include "auv_interfaces/StateStamped.h"
 
 namespace mission_control
 {
-class DepthHeadingBehavior : public Behavior
-{
- public:
-  DepthHeadingBehavior(const std::string& name, const BT::NodeConfiguration& config);
-
-  BT::NodeStatus behaviorRunningProcess();
-
-  static BT::PortsList providedPorts()
+  class DepthHeadingBehavior : public Behavior
   {
-    BT::PortsList ports =
+  public:
+    DepthHeadingBehavior(const std::string &name, const BT::NodeConfiguration &config);
+
+    BT::NodeStatus behaviorRunningProcess();
+
+    static BT::PortsList providedPorts()
     {
-      BT::InputPort<double>("depth", 0.0, "depth"),
-      BT::InputPort<double>("heading", 0.0, "heading"),
-      BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
-      BT::InputPort<double>("depth_tol", 0.0, "depth_tol"),
-      BT::InputPort<double>("heading_tol", 0.0, "heading_tol"),
-      BT::InputPort<double>("time_out", 0.0, "time_out")
-    };
-    return ports;
-  }
+      BT::PortsList ports =
+          {
+              BT::InputPort<double>("depth", 0.0, "depth"),
+              BT::InputPort<double>("heading", 0.0, "heading"),
+              BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
+              BT::InputPort<double>("depth_tol", 0.0, "depth_tol"),
+              BT::InputPort<double>("heading_tol", 0.0, "heading_tol"),
+              BT::InputPort<double>("time_out", 0.0, "time_out")};
+      return ports;
+    }
 
- private:
-  ros::NodeHandle nodeHandle_;
-  ros::Publisher depthHeadingBehaviorPub;
-  ros::Subscriber subCorrectedData_;
+  private:
+    ros::NodeHandle nodeHandle_;
+    ros::Publisher depthHeadingBehaviorPub;
+    ros::Subscriber subCorrectedData_;
 
-  double depth_;
-  double heading_;
-  double speedKnots_;
-  double timeOut_;
+    double depth_;
+    double heading_;
+    double speedKnots_;
+    double timeOut_;
 
-  bool depthEnable_;
-  bool headingEnable_;
-  bool speedKnotsEnable_;
+    bool depthEnable_;
+    bool headingEnable_;
+    bool speedKnotsEnable_;
 
-  double depthTolerance_;
-  double headingTolerance_;
+    double depthTolerance_;
+    double headingTolerance_;
 
-  void correctedDataCallback(const pose_estimator::CorrectedData& data);
-  bool goalHasBeenPublished_;
-  void publishGoalMsg();
-  ros::Time behaviorStartTime_;
-  bool behaviorComplete_;
-};
+    void stateDataCallback(const auv_interfaces::StateStamped &data);
+    bool goalHasBeenPublished_;
+    void publishGoalMsg();
+    ros::Time behaviorStartTime_;
+    bool behaviorComplete_;
+  };
 
 }  //  namespace mission_control
 

--- a/mission_control/include/mission_control/behaviors/fixed_rudder.h
+++ b/mission_control/include/mission_control/behaviors/fixed_rudder.h
@@ -45,7 +45,7 @@
 
 #include "mission_control/FixedRudder.h"
 #include "mission_control/behavior.h"
-#include "pose_estimator/CorrectedData.h"
+#include "auv_interfaces/StateStamped.h"
 
 namespace mission_control
 {
@@ -74,7 +74,7 @@ class MoveWithFixedRudder : public Behavior
  private:
   ros::NodeHandle nodeHandle_;
   ros::Publisher fixedRudderBehaviorPub_;
-  ros::Subscriber subCorrectedData_;
+  ros::Subscriber subStateData_;
 
   double depth_;
   double altitude_;
@@ -91,7 +91,7 @@ class MoveWithFixedRudder : public Behavior
   double rudderTolerance_;
   double altitudeTolerance_;
 
-  void correctedDataCallback(const pose_estimator::CorrectedData& data);
+  void stateDataCallback(const auv_interfaces::StateStamped &data);
   bool goalHasBeenPublished_;
   void publishGoalMsg();
   ros::Time behaviorStartTime_;

--- a/mission_control/include/mission_control/behaviors/waypoint.h
+++ b/mission_control/include/mission_control/behaviors/waypoint.h
@@ -45,7 +45,7 @@
 
 #include "mission_control/Waypoint.h"
 #include "mission_control/behavior.h"
-#include "pose_estimator/CorrectedData.h"
+#include "auv_interfaces/StateStamped.h"
 
 namespace mission_control
 {
@@ -55,30 +55,29 @@ void latLongtoUTM(double latitude, double longitude, double* ptrNorthing, double
 
 class GoToWaypoint : public Behavior
 {
- public:
-  GoToWaypoint(const std::string& name, const BT::NodeConfiguration& config);
+public:
+  GoToWaypoint(const std::string &name, const BT::NodeConfiguration &config);
 
   BT::NodeStatus behaviorRunningProcess();
 
   static BT::PortsList providedPorts()
   {
     BT::PortsList ports =
-    {
-      BT::InputPort<double>("depth", 0.0, "depth"),
-      BT::InputPort<double>("altitude", 0.0, "altitude"),
-      BT::InputPort<double>("latitude", 0.0, "latitude"),
-      BT::InputPort<double>("longitude", 0.0, "longitude"),
-      BT::InputPort<double>("wp_radius", 0.0, "wp_radius"),
-      BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
-      BT::InputPort<double>("time_out", 0.0, "time_out")
-    };
+        {
+            BT::InputPort<double>("depth", 0.0, "depth"),
+            BT::InputPort<double>("altitude", 0.0, "altitude"),
+            BT::InputPort<double>("latitude", 0.0, "latitude"),
+            BT::InputPort<double>("longitude", 0.0, "longitude"),
+            BT::InputPort<double>("wp_radius", 0.0, "wp_radius"),
+            BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
+            BT::InputPort<double>("time_out", 0.0, "time_out")};
     return ports;
   }
 
- private:
+private:
   ros::NodeHandle nodeHandle_;
   ros::Publisher waypointBehaviorPub_;
-  ros::Subscriber subCorrectedData_;
+  ros::Subscriber subStateData_;
 
   double altitude_;
   double depth_;
@@ -97,7 +96,7 @@ class GoToWaypoint : public Behavior
 
   double depthTolerance_;
 
-  void correctedDataCallback(const pose_estimator::CorrectedData& data);
+  void stateDataCallback(const auv_interfaces::StateStamped &data);
   bool goalHasBeenPublished_;
   void publishGoalMsg();
   ros::Time behaviorStartTime_;

--- a/mission_control/package.xml
+++ b/mission_control/package.xml
@@ -10,30 +10,30 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>actionlib_msgs</build_depend>
+  <build_depend>auv_interfaces</build_depend>
   <build_depend>behaviortree_cpp_v3</build_depend>
   <build_depend>health_monitor</build_depend>
   <build_depend>jaus_ros_bridge</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>payload_manager</build_depend>
-  <build_depend>pose_estimator</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_export_depend>auv_interfaces</build_export_depend>
   <build_export_depend>health_monitor</build_export_depend>
   <build_export_depend>payload_manager</build_export_depend>
-  <build_export_depend>pose_estimator</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>actionlib</exec_depend>
   <exec_depend>actionlib_msgs</exec_depend>
+  <exec_depend>auv_interfaces</exec_depend>
   <exec_depend>behaviortree_cpp_v3</exec_depend>
   <exec_depend>health_monitor</exec_depend>
   <exec_depend>jaus_ros_bridge</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>payload_manager</exec_depend>
-  <exec_depend>pose_estimator</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/mission_control/src/behaviors/attitude_servo.cpp
+++ b/mission_control/src/behaviors/attitude_servo.cpp
@@ -134,13 +134,16 @@ void AttitudeServoBehavior::publishGoalMsg()
   attitudeServoBehaviorPub_.publish(msg);
 }
 
-void AttitudeServoBehavior::correctedDataCallback(const pose_estimator::CorrectedData& data)
+void AttitudeServoBehavior::stateDataCallback(const auv_interfaces::StateStamped& data)
 {
   behaviorComplete_ = true;
+  double roll = data.state.manoeuvring.pose.mean.orientation.x;
+  double pitch = data.state.manoeuvring.pose.mean.orientation.y;
+  double yaw = data.state.manoeuvring.pose.mean.orientation.z;
 
-  if (rollEnable_ && fabs(roll_ - data.rpy_ang.x) > rollTolerance_) behaviorComplete_ = false;
-  if (pitchEnable_ && fabs(pitch_ - data.rpy_ang.y) > pitchTolerance_) behaviorComplete_ = false;
-  if (yawEnable_ && fabs(yaw_ - data.rpy_ang.z) > yawTolerance_) behaviorComplete_ = false;
+  if (rollEnable_ && abs(roll_ - roll) > rollTolerance_) behaviorComplete_ = false;
+  if (pitchEnable_ && abs(pitch_ - pitch) > pitchTolerance_) behaviorComplete_ = false;
+  if (yawEnable_ && abs(yaw_ - yaw) > yawTolerance_) behaviorComplete_ = false;
 
   // TODO(QNA): check shaft speed and/or battery position?
   // TODO(QNA): make sure our RPY rates are close to zero?

--- a/mission_control/src/behaviors/depth_heading.cpp
+++ b/mission_control/src/behaviors/depth_heading.cpp
@@ -39,8 +39,8 @@
 
 using mission_control::DepthHeadingBehavior;
 
-DepthHeadingBehavior::DepthHeadingBehavior(const std::string& name,
-                                           const BT::NodeConfiguration& config)
+DepthHeadingBehavior::DepthHeadingBehavior(const std::string &name,
+                                           const BT::NodeConfiguration &config)
     : Behavior(name, config)
 {
   depthEnable_ = false;
@@ -53,13 +53,16 @@ DepthHeadingBehavior::DepthHeadingBehavior(const std::string& name,
   speedKnots_ = 0.0;
 
   getInput<double>("depth", depth_);
-  if (depth_ != 0.0) depthEnable_ = true;
+  if (depth_ != 0.0)
+    depthEnable_ = true;
 
   getInput<double>("heading", heading_);
-  if (heading_ != 0.0) headingEnable_ = true;
+  if (heading_ != 0.0)
+    headingEnable_ = true;
 
   getInput<double>("speed_knots", speedKnots_);
-  if (speedKnots_ != 0.0) speedKnotsEnable_ = true;
+  if (speedKnots_ != 0.0)
+    speedKnotsEnable_ = true;
 
   getInput<double>("depth_tol", depthTolerance_);
   getInput<double>("heading_tol", headingTolerance_);
@@ -123,9 +126,10 @@ void DepthHeadingBehavior::publishGoalMsg()
   depthHeadingBehaviorPub.publish(msg);
 }
 
-void DepthHeadingBehavior::correctedDataCallback(const pose_estimator::CorrectedData& data)
+void DepthHeadingBehavior::void stateDataCallback(const auv_interfaces::StateStamped& data)
 {
+  double heading = data.state.manoeuvring.pose.mean.orientation.z;
   // A quick check to see if our RPY angles match
-  if (headingEnable_ && (fabs(heading_ - data.rpy_ang.z) < headingTolerance_))
+  if (headingEnable_ && (fabs(heading_ - heading) < headingTolerance_))
     behaviorComplete_ = true;
 }

--- a/mission_control/src/behaviors/fixed_rudder.cpp
+++ b/mission_control/src/behaviors/fixed_rudder.cpp
@@ -33,8 +33,9 @@
  *********************************************************************/
 
 // Original version: Christopher Scianna Christopher.Scianna@us.QinetiQ.com
-#include <string>
 #include "mission_control/behaviors/fixed_rudder.h"
+
+#include <string>
 
 using mission_control::MoveWithFixedRudder;
 
@@ -65,8 +66,7 @@ MoveWithFixedRudder::MoveWithFixedRudder(const std::string& name,
   getInput<double>("depth_tol", depthTolerance_);
   getInput<double>("altitude_tol", altitudeTolerance_);
 
-  subCorrectedData_ = nodeHandle_.subscribe("/pose/corrected_data", 1,
-                                            &MoveWithFixedRudder::correctedDataCallback, this);
+  subStateData_ = nodeHandle_.subscribe("/state", 1, &MoveWithFixedRudder::stateDataCallback, this);
 
   goalHasBeenPublished_ = false;
   fixedRudderBehaviorPub_ =
@@ -107,7 +107,7 @@ void MoveWithFixedRudder::publishGoalMsg()
   fixedRudderBehaviorPub_.publish(msg);
 }
 
-void MoveWithFixedRudder::correctedDataCallback(const pose_estimator::CorrectedData& data)
+void MoveWithFixedRudder::stateDataCallback(const auv_interfaces::StateStamped& data)
 {
   // A quick check to see if our depth matches, note: rudder is not part of corrected data.
   // TODO(QNA): put back in when depth working  if (depthEnable_ && (abs(depth_ - data.depth) >

--- a/mission_control/test/test_attitude_servo_behavior.py
+++ b/mission_control/test/test_attitude_servo_behavior.py
@@ -52,7 +52,7 @@ class TestAttitudeServoBehavior(unittest.TestCase):
         -   Load the mission attitude_servo_mission_test.xml
         -   Execute the mission
         -   Check if the behavior publishes the goal
-        -   Simulate auv_inteface data to finish the behavior
+        -   Simulate auv_interfaces/StateStamped data to finish the behavior
         -   Test if the mission is SUCCESS
     """
 
@@ -108,11 +108,11 @@ class TestAttitudeServoBehavior(unittest.TestCase):
                         msg='Mission control must publish goals')
 
         # send data to finish the mission
-        auv_interface_data = StateStamped()
-        auv_interface_data.state.manoeuvring.pose.mean.orientation.x = 1.0
-        auv_interface_data.state.manoeuvring.pose.mean.orientation.y = 1.0
-        auv_interface_data.state.manoeuvring.pose.mean.orientation.z = 1.0
-        self.simulated_auv_interface_data_pub.publish(auv_interface_data)
+        msg = StateStamped()
+        msg.state.manoeuvring.pose.mean.orientation.x = 1.0
+        msg.state.manoeuvring.pose.mean.orientation.y = 1.0
+        msg.state.manoeuvring.pose.mean.orientation.z = 1.0
+        self.simulated_auv_interface_data_pub.publish(msg)
 
         def success_mission_status_is_reported():
             return self.mission.execute_mission_state == ReportExecuteMissionState.COMPLETE

--- a/mission_control/test/test_attitude_servo_behavior.py
+++ b/mission_control/test/test_attitude_servo_behavior.py
@@ -41,8 +41,7 @@ import rospy
 import rostest
 from mission_control.msg import ReportExecuteMissionState
 from mission_control.msg import AttitudeServo
-from pose_estimator.msg import CorrectedData
-from geometry_msgs.msg import Vector3
+from auv_interfaces.msg import StateStamped
 from mission_interface import MissionInterface
 from mission_interface import wait_for
 
@@ -53,7 +52,7 @@ class TestAttitudeServoBehavior(unittest.TestCase):
         -   Load the mission attitude_servo_mission_test.xml
         -   Execute the mission
         -   Check if the behavior publishes the goal
-        -   Simulate PoseEstimator data to finish the behavior
+        -   Simulate auv_inteface data to finish the behavior
         -   Test if the mission is SUCCESS
     """
 
@@ -71,9 +70,9 @@ class TestAttitudeServoBehavior(unittest.TestCase):
             AttitudeServo,
             self.attitude_servo_goal_callback)
 
-        self.simulated_pose_estimator_pub = rospy.Publisher(
-            '/pose/corrected_data',
-            CorrectedData,
+        self.simulated_auv_interface_data_pub = rospy.Publisher(
+            '/state',
+            StateStamped,
             queue_size=1)
 
     def attitude_servo_goal_callback(self, msg):
@@ -89,8 +88,8 @@ class TestAttitudeServoBehavior(unittest.TestCase):
         yaw = self.mission.get_behavior_parameter('yaw')
         speed_knots = self.mission.get_behavior_parameter('speed_knots')
         enable_mask = 0
-        
-        #Calculate the mask
+
+        # Calculate the mask
         def get_mask(value, mask):
             return mask if value > 0 else 0
         enable_mask |= get_mask(roll, AttitudeServo.ROLL_ENA)
@@ -109,14 +108,11 @@ class TestAttitudeServoBehavior(unittest.TestCase):
                         msg='Mission control must publish goals')
 
         # send data to finish the mission
-        rpy_data = Vector3()
-        pose_estimator_corrected_data = CorrectedData()
-        rpy_data.x = 1.0
-        rpy_data.y = 1.0
-        rpy_data.z = 1.0
-        pose_estimator_corrected_data.rpy_ang = rpy_data
-        self.simulated_pose_estimator_pub.publish(
-            pose_estimator_corrected_data)
+        auv_interface_data = StateStamped()
+        auv_interface_data.state.manoeuvring.pose.mean.orientation.x = 1.0
+        auv_interface_data.state.manoeuvring.pose.mean.orientation.y = 1.0
+        auv_interface_data.state.manoeuvring.pose.mean.orientation.z = 1.0
+        self.simulated_auv_interface_data_pub.publish(auv_interface_data)
 
         def success_mission_status_is_reported():
             return self.mission.execute_mission_state == ReportExecuteMissionState.COMPLETE


### PR DESCRIPTION
# Description

This PR modifies the mission control behavior to use with auv_interfaces::StateStamped instead of pose_estimator::CorrectedData. The test to be used with this behavior were also updated.

This PR depends on:
- Refactor pose_estimator package #91, #93, #99
- Replace pose_estimator::CorrectedData with auv_interfaces::StateStamped #94

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Linter tests are passing

# How To Test
```sh
rostest mission_control test_mission_control_behaviors.test
```