### PR TITLE
Altitude heading behavior

### DIFF
--- a/autopilot/include/autopilot/autopilot.h
+++ b/autopilot/include/autopilot/autopilot.h
@@ -60,6 +60,7 @@
 #include "jaus_ros_bridge/ActivateManualControl.h"
 #include "mission_manager/AttitudeServo.h"
 #include "mission_manager/DepthHeading.h"
+#include "mission_manager/AltitudeHeading.h"
 #include "mission_manager/FixedRudder.h"
 #include "mission_manager/ReportExecuteMissionState.h"
 #include "mission_manager/ReportHeartbeat.h"
@@ -92,12 +93,14 @@ class AutoPilotNode
   ros::Subscriber missionMgrHeartBeatSub;
   ros::Subscriber setAttitudeBehaviorSub;
   ros::Subscriber setDepthHeadingBehaviorSub;
+  ros::Subscriber setAltitudeHeadingBehaviorSub;
   ros::Subscriber setFixedRudderBehaviorSub;
 
   control_toolbox::Pid rollPIDController;
   control_toolbox::Pid pitchPIDController;
   control_toolbox::Pid yawPidController;
   control_toolbox::Pid depthPIDController;
+  control_toolbox::Pid altitudePIDController;
 
   bool autoPilotInControl;
   bool missionMode;
@@ -125,7 +128,13 @@ class AutoPilotNode
   double depthDGain;
   double depthIMax;
   double depthIMin;
-
+  
+  double altitudePGain;
+  double altitudeIGain;
+  double altitudeDGain;
+  double altitudeIMax;
+  double altitudeIMin;
+  
   void stateCallback(const auv_interfaces::StateStamped& msg);
   void missionStatusCallback(const mission_manager::ReportExecuteMissionState& data);
 
@@ -144,6 +153,7 @@ class AutoPilotNode
   double currentPitch;
   double currentYaw;
   double currentDepth;
+  double currentAltitude;
 
   double desiredRoll;
   double desiredPitch;
@@ -151,6 +161,7 @@ class AutoPilotNode
   double desiredDepth;
   double desiredRudder;
   double desiredSpeed;
+  double desiredAltitude;
 
   double minimalSpeed;       // knots
   double rpmPerKnot;
@@ -160,12 +171,14 @@ class AutoPilotNode
   bool speedControlEnabled;  // Autopilot controls acceleration if true
   bool fixedRudder;          // Robot cordinate system for yaw if true
   bool depthControl;         // Depth if true, pitch if false
+  bool altitudeControl;
   bool autopilotEnabled;     // Autopilot if true, OCU if false
 
   bool allowReverseThrusterAutopilot;  // allow negative RPM if true
 
   double maxCtrlFinAngle;  // Max fin angle (degrees)
   double maxDepthCommand;    // Max amount the depth affects the fin angle (degrees)
+  double maxAltitudeCommand;
 
   boost::shared_ptr<boost::thread> m_thread;
 
@@ -174,6 +187,7 @@ class AutoPilotNode
   void attitudeServoCallback(const mission_manager::AttitudeServo& msg);
   void depthHeadingCallback(const mission_manager::DepthHeading& msg);
   void fixedRudderCallback(const mission_manager::FixedRudder& msg);
+  void altitudeHeadingCallback(const mission_manager::AltitudeHeading& msg);
 
   // Mask that keeps tracks of active behaviors
   boost::mutex behaviorMutex;

--- a/autopilot/launch/autopilot.launch
+++ b/autopilot/launch/autopilot.launch
@@ -45,6 +45,14 @@
     <param name="depth_imax" type="double" value="20.0" />
     <param name="depth_imin" type="double" value="-20.0" />
     <param name="depth_d" type="double" value="0.0" />
+  
+    <param name="max_altitude_command" type="double" value="25.0" />
+    <param name="altitude_p" type="double" value="1.0" />
+    <param name="altitude_i" type="double" value="0.0" />
+    <param name="altitude_imax" type="double" value="0.0" />
+    <param name="altitude_imin" type="double" value="0.0" />
+    <param name="altitude_d" type="double" value="0.0" />
+
   </node>
 
 </launch>

--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(${PROJECT_NAME} SHARED
   src/behaviors/fixed_rudder.cpp
   src/behaviors/depth_heading.cpp
   src/behaviors/attitude_servo.cpp
+  src/behaviors/altitude_heading.cpp
 )
 
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 add_message_files(
   FILES
+  AltitudeHeading.msg
   AttitudeServo.msg
   DepthHeading.msg
   FixedRudder.msg

--- a/mission_control/include/mission_control/behaviors/altitude_heading.h
+++ b/mission_control/include/mission_control/behaviors/altitude_heading.h
@@ -70,9 +70,13 @@ class AltitudeHeadingBehavior : public Behavior
   }
 
  private:
+  void stateDataCallback(const auv_interfaces::StateStamped &data);
+  void publishGoalMsg();
+
   ros::NodeHandle nodeHandle_;
   ros::Publisher altitudeHeadingBehaviorPub_;
   ros::Subscriber subCorrectedData_;
+  ros::Time behaviorStartTime_;
 
   double altitude_;
   double heading_;
@@ -87,10 +91,7 @@ class AltitudeHeadingBehavior : public Behavior
   double altitudeTolerance_;
   double headingTolerance_;
 
-  void stateDataCallback(const auv_interfaces::StateStamped &data);
   bool goalHasBeenPublished_;
-  void publishGoalMsg();
-  ros::Time behaviorStartTime_;
   bool behaviorComplete_;
 };
 

--- a/mission_control/include/mission_control/behaviors/altitude_heading.h
+++ b/mission_control/include/mission_control/behaviors/altitude_heading.h
@@ -60,12 +60,12 @@ class AltitudeHeadingBehavior : public Behavior
 
   static BT::PortsList providedPorts()
   {
-    BT::PortsList ports = {BT::InputPort<double>("altitude", 0.0, "altitude"),  //  NOLINT
-                           BT::InputPort<double>("heading", 0.0, "heading"),
-                           BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
+    BT::PortsList ports = {BT::InputPort<double>("altitude", "altitude"),  //  NOLINT
+                           BT::InputPort<double>("heading", "heading"),
+                           BT::InputPort<double>("speed_knots", "speed_knots"),
                            BT::InputPort<double>("altitude_tol", 0.0, "altitude_tol"),
                            BT::InputPort<double>("heading_tol", 0.0, "heading_tol"),
-                           BT::InputPort<double>("time_out", 0.0, "time_out")};
+                           BT::InputPort<double>("time_out", "time_out")};
     return ports;
   }
 

--- a/mission_control/include/mission_control/behaviors/altitude_heading.h
+++ b/mission_control/include/mission_control/behaviors/altitude_heading.h
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+// Original version: Christopher Scianna Christopher.Scianna@us.QinetiQ.com
+
+#ifndef MISSION_CONTROL_BEHAVIORS_ALTITUDE_HEADING_H
+#define MISSION_CONTROL_BEHAVIORS_ALTITUDE_HEADING_H
+
+#include <behaviortree_cpp_v3/basic_types.h>
+#include <behaviortree_cpp_v3/behavior_tree.h>
+#include <behaviortree_cpp_v3/bt_factory.h>
+#include <ros/ros.h>
+
+#include <string>
+
+#include "auv_interfaces/StateStamped.h"
+#include "mission_control/AltitudeHeading.h"
+#include "mission_control/behavior.h"
+
+namespace mission_control
+{
+
+class AltitudeHeadingBehavior : public Behavior
+{
+ public:
+  AltitudeHeadingBehavior(const std::string &name, const BT::NodeConfiguration &config);
+
+  BT::NodeStatus behaviorRunningProcess();
+
+  static BT::PortsList providedPorts()
+  {
+    BT::PortsList ports = {BT::InputPort<double>("altitude", 0.0, "altitude"),  //  NOLINT
+                           BT::InputPort<double>("heading", 0.0, "heading"),
+                           BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
+                           BT::InputPort<double>("altitude_tol", 0.0, "altitude_tol"),
+                           BT::InputPort<double>("heading_tol", 0.0, "heading_tol"),
+                           BT::InputPort<double>("time_out", 0.0, "time_out")};
+    return ports;
+  }
+
+ private:
+  ros::NodeHandle nodeHandle_;
+  ros::Publisher altitudeHeadingBehaviorPub_;
+  ros::Subscriber subCorrectedData_;
+
+  double altitude_;
+  double heading_;
+  double speedKnots_;
+  double timeOut_;
+
+  bool altitudeEnable_;
+  bool headingEnable_;
+  bool speedKnotsEnable_;
+  bool timeOutEnable_;
+
+  double altitudeTolerance_;
+  double headingTolerance_;
+
+  void stateDataCallback(const auv_interfaces::StateStamped &data);
+  bool goalHasBeenPublished_;
+  void publishGoalMsg();
+  ros::Time behaviorStartTime_;
+  bool behaviorComplete_;
+};
+
+}  //  namespace mission_control
+
+#endif  //  MISSION_CONTROL_BEHAVIORS_ALTITUDE_HEADING_H

--- a/mission_control/src/behaviors/altitude_heading.cpp
+++ b/mission_control/src/behaviors/altitude_heading.cpp
@@ -48,25 +48,21 @@ AltitudeHeadingBehavior::AltitudeHeadingBehavior(const std::string &name,
   speedKnotsEnable_ = false;
   timeOutEnable_ = false;
 
-  getInput<double>("altitude", altitude_);
-  if (altitude_)
+  if (getInput<double>("altitude", altitude_))
   {
     altitudeEnable_ = true;
     getInput<double>("altitude_tol", altitudeTolerance_);
   }
 
-  getInput<double>("heading", heading_);
-  if (heading_)
+  if (getInput<double>("heading", heading_))
   {
     headingEnable_ = true;
     getInput<double>("heading_tol", headingTolerance_);
   }
 
-  getInput<double>("speed_knots", speedKnots_);
-  if (speedKnots_) speedKnotsEnable_ = true;
+  if (getInput<double>("speed_knots", speedKnots_)) speedKnotsEnable_ = true;
 
-  getInput<double>("time_out", timeOut_);
-  if (timeOut_) timeOutEnable_ = true;
+  if (getInput<double>("time_out", timeOut_)) timeOutEnable_ = true;
 
   subCorrectedData_ =
       nodeHandle_.subscribe("/state", 1, &AltitudeHeadingBehavior::stateDataCallback, this);

--- a/mission_control/src/behaviors/altitude_heading.cpp
+++ b/mission_control/src/behaviors/altitude_heading.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, QinetiQ, Inc.
+ *  Copyright (c) 2021, QinetiQ, Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -125,5 +125,5 @@ void AltitudeHeadingBehavior::stateDataCallback(const auv_interfaces::StateStamp
 {
   double heading = data.state.manoeuvring.pose.mean.orientation.z;
   // A quick check to see if our RPY angles match
-  if (headingEnable_ && (abs(heading_ - heading) < headingTolerance_)) behaviorComplete_ = true;
+  behaviorComplete_ = headingEnable_ && (abs(heading_ - heading) < headingTolerance_);
 }

--- a/mission_control/src/behaviors/altitude_heading.cpp
+++ b/mission_control/src/behaviors/altitude_heading.cpp
@@ -1,0 +1,133 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+// Original version: Christopher Scianna Christopher.Scianna@us.QinetiQ.com
+#include "mission_control/behaviors/altitude_heading.h"
+
+#include <string>
+
+using mission_control::AltitudeHeadingBehavior;
+
+AltitudeHeadingBehavior::AltitudeHeadingBehavior(const std::string &name,
+                                                 const BT::NodeConfiguration &config)
+    : Behavior(name, config)
+{
+  altitudeEnable_ = false;
+  headingEnable_ = false;
+  speedKnotsEnable_ = false;
+  timeOutEnable_ = false;
+
+  getInput<double>("altitude", altitude_);
+  if (altitude_)
+  {
+    altitudeEnable_ = true;
+    getInput<double>("altitude_tol", altitudeTolerance_);
+  }
+
+  getInput<double>("heading", heading_);
+  if (heading_)
+  {
+    headingEnable_ = true;
+    getInput<double>("heading_tol", headingTolerance_);
+  }
+
+  getInput<double>("speed_knots", speedKnots_);
+  if (speedKnots_) speedKnotsEnable_ = true;
+
+  getInput<double>("time_out", timeOut_);
+  if (timeOut_) timeOutEnable_ = true;
+
+  subCorrectedData_ =
+      nodeHandle_.subscribe("/state", 1, &AltitudeHeadingBehavior::stateDataCallback, this);
+
+  altitudeHeadingBehaviorPub_ =
+      nodeHandle_.advertise<mission_control::AltitudeHeading>("/mngr/altitude_heading", 100);
+
+  goalHasBeenPublished_ = false;
+  behaviorComplete_ = false;
+  behaviorStartTime_ = ros::Time::now();
+}
+
+BT::NodeStatus AltitudeHeadingBehavior::behaviorRunningProcess()
+{
+  if (!goalHasBeenPublished_)
+  {
+    behaviorComplete_ = false;
+    publishGoalMsg();
+    behaviorStartTime_ = ros::Time::now();
+    goalHasBeenPublished_ = true;
+  }
+  else
+  {
+    ros::Duration delta_t = ros::Time::now() - behaviorStartTime_;
+    if (delta_t.toSec() > timeOut_ && timeOutEnable_)
+    {
+      goalHasBeenPublished_ = false;
+      setStatus(BT::NodeStatus::FAILURE);
+    }
+    else
+    {
+      if (behaviorComplete_)
+      {
+        setStatus(BT::NodeStatus::SUCCESS);
+        goalHasBeenPublished_ = false;
+      }
+    }
+  }
+  return status();
+}
+
+void AltitudeHeadingBehavior::publishGoalMsg()
+{
+  AltitudeHeading msg;
+
+  msg.altitude = altitude_;
+  msg.heading = heading_;
+  msg.speed_knots = speedKnots_;
+
+  msg.ena_mask = 0x0;
+  if (altitudeEnable_) msg.ena_mask |= AltitudeHeading::ALTITUDE_ENA;
+  if (headingEnable_) msg.ena_mask |= AltitudeHeading::HEADING_ENA;
+  if (speedKnotsEnable_) msg.ena_mask |= AltitudeHeading::SPEED_KNOTS_ENA;
+
+  msg.header.stamp = ros::Time::now();
+  altitudeHeadingBehaviorPub_.publish(msg);
+}
+
+void AltitudeHeadingBehavior::stateDataCallback(const auv_interfaces::StateStamped &data)
+{
+  double heading = data.state.manoeuvring.pose.mean.orientation.z;
+  // A quick check to see if our RPY angles match
+  if (headingEnable_ && (abs(heading_ - heading) < headingTolerance_)) behaviorComplete_ = true;
+}

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -42,6 +42,7 @@
 #include "mission_control/behaviors/fixed_rudder.h"
 #include "mission_control/behaviors/depth_heading.h"
 #include "mission_control/behaviors/attitude_servo.h"
+#include "mission_control/behaviors/altitude_heading.h"
 
 #include <string>
 
@@ -68,6 +69,7 @@ class MissionBehaviorTreeFactory : public BT::BehaviorTreeFactory
     this->registerNodeType<mission_control::MoveWithFixedRudder>("MoveWithFixedRudder");
     this->registerNodeType<mission_control::DepthHeadingBehavior>("DepthHeadingBehavior");
     this->registerNodeType<mission_control::AttitudeServoBehavior>("AttitudeServoBehavior");
+    this->registerNodeType<mission_control::AltitudeHeadingBehavior>("AltitudeHeadingBehavior");
   }
 };
 

--- a/mission_control/test/mission_interface.py
+++ b/mission_control/test/mission_interface.py
@@ -126,7 +126,6 @@ class MissionInterface:
         tree = ElementTree.parse(self.full_path)
         self.mission_behavior_parameters = tree.find('.//' + mission_behavior)
 
-    def get_behavior_parameter(self, behavior_parameter):
+    def get_behavior_parameter(self, name):
         # return the parameter of the mission (mission/behavior/parameter)
-        parameter = self.mission_behavior_parameters.attrib.get(behavior_parameter)
-        return float(parameter) if parameter else None
+        return self.mission_behavior_parameters.attrib.get(name)

--- a/mission_control/test/mission_interface.py
+++ b/mission_control/test/mission_interface.py
@@ -128,4 +128,5 @@ class MissionInterface:
 
     def get_behavior_parameter(self, behavior_parameter):
         # return the parameter of the mission (mission/behavior/parameter)
-        return float(self.mission_behavior_parameters.attrib.get(behavior_parameter))
+        parameter = self.mission_behavior_parameters.attrib.get(behavior_parameter)
+        return float(parameter) if parameter else None

--- a/mission_control/test/test_altitude_heading_behavior.py
+++ b/mission_control/test/test_altitude_heading_behavior.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+"""
+import sys
+import os
+import unittest
+import math
+import rosnode
+import rospy
+import rostest
+from mission_control.msg import ReportExecuteMissionState
+from mission_control.msg import AltitudeHeading
+from auv_interfaces.msg import StateStamped
+from mission_interface import MissionInterface
+from mission_interface import wait_for
+
+
+class TestAltitudeHeadingBehavior(unittest.TestCase):
+    """ 
+        The test loads and execute an altitude heading behavior.
+        -   Load the mission altitude_heading_mission_test.xml
+        -   Execute the mission
+        -   Check if the behavior publishes the goal
+        -   Simulate auv_inteface data to finish the behavior
+        -   Test if the mission is COMPLETE
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rospy.init_node('test_altitude_heading_behavior')
+
+    def setUp(self):
+        self.altitude_heading_goal = AltitudeHeading()
+        self.mission = MissionInterface()
+
+        self.altitude_heading_msg = rospy.Subscriber(
+            '/mngr/altitude_heading',
+            AltitudeHeading,
+            self.altitude_heading_goal_callback)
+
+        self.simulated_auv_interface_data_pub = rospy.Publisher(
+            '/state',
+            StateStamped,
+            queue_size=1)
+
+    def altitude_heading_goal_callback(self, msg):
+        self.altitude_heading_goal = msg
+
+    def test_mission_with_altitude_heading_behavior(self):
+        self.mission.load_mission('altitude_heading_mission_test.xml')
+        self.mission.execute_mission()
+        self.mission.read_behavior_parameters('AltitudeHeadingBehavior')
+        altitude = self.mission.get_behavior_parameter('altitude')
+        heading = self.mission.get_behavior_parameter('heading')
+        speed_knots = self.mission.get_behavior_parameter('speed_knots')
+        enable_mask = 0
+
+        # Calculate the mask
+        def get_mask(value, mask):
+            return mask if value > 0 else 0
+        enable_mask |= get_mask(altitude, AltitudeHeading.ALTITUDE_ENA)
+        enable_mask |= get_mask(heading, AltitudeHeading.HEADING_ENA)
+        enable_mask |= get_mask(speed_knots, AltitudeHeading.SPEED_KNOTS_ENA)
+
+        def altitude_heading_goals_are_set():
+            return (self.altitude_heading_goal.altitude == altitude and
+                    self.altitude_heading_goal.heading == heading and
+                    self.altitude_heading_goal.speed_knots == speed_knots and
+                    self.altitude_heading_goal.ena_mask == enable_mask)
+        self.assertTrue(wait_for(altitude_heading_goals_are_set),
+                        msg='Mission control must publish goals')
+
+        # send data to finish the mission
+        auv_interface_data = StateStamped()
+        auv_interface_data.state.manoeuvring.pose.mean.orientation.x = 0.0
+        auv_interface_data.state.manoeuvring.pose.mean.orientation.y = 0.0
+        auv_interface_data.state.manoeuvring.pose.mean.orientation.z = 2.0
+        self.simulated_auv_interface_data_pub.publish(auv_interface_data)
+
+        def success_mission_status_is_reported():
+            return self.mission.execute_mission_state == ReportExecuteMissionState.COMPLETE
+        self.assertTrue(wait_for(success_mission_status_is_reported),
+                        msg='Mission control must report COMPLETE')
+
+
+if __name__ == "__main__":
+    rostest.rosrun('mission_control', 'mission_control_test_altitude_heading_behavior',
+                   TestAltitudeHeadingBehavior)

--- a/mission_control/test/test_altitude_heading_behavior.py
+++ b/mission_control/test/test_altitude_heading_behavior.py
@@ -2,7 +2,7 @@
 """
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2020, QinetiQ, Inc.
+ *  Copyright (c) 2021, QinetiQ, Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -76,6 +76,7 @@ class TestAltitudeHeadingBehavior(unittest.TestCase):
 
     def altitude_heading_goal_callback(self, msg):
         self.altitude_heading_goal = msg
+        rospy.loginfo(msg)
 
     def test_mission_with_altitude_heading_behavior(self):
         self.mission.load_mission('altitude_heading_mission_test.xml')
@@ -88,15 +89,18 @@ class TestAltitudeHeadingBehavior(unittest.TestCase):
 
         # Calculate the mask
         def get_mask(value, mask):
-            return mask if value > 0 else 0
+            return mask if value else 0
         enable_mask |= get_mask(altitude, AltitudeHeading.ALTITUDE_ENA)
         enable_mask |= get_mask(heading, AltitudeHeading.HEADING_ENA)
         enable_mask |= get_mask(speed_knots, AltitudeHeading.SPEED_KNOTS_ENA)
 
+        def check_parameter(value):
+            return value if value else 0
+
         def altitude_heading_goals_are_set():
-            return (self.altitude_heading_goal.altitude == altitude and
-                    self.altitude_heading_goal.heading == heading and
-                    self.altitude_heading_goal.speed_knots == speed_knots and
+            return (self.altitude_heading_goal.altitude == check_parameter(altitude) and
+                    self.altitude_heading_goal.heading == check_parameter(heading) and
+                    self.altitude_heading_goal.speed_knots == check_parameter(speed_knots) and
                     self.altitude_heading_goal.ena_mask == enable_mask)
         self.assertTrue(wait_for(altitude_heading_goals_are_set),
                         msg='Mission control must publish goals')

--- a/mission_control/test/test_altitude_heading_behavior.py
+++ b/mission_control/test/test_altitude_heading_behavior.py
@@ -47,7 +47,7 @@ from mission_interface import wait_for
 
 
 class TestAltitudeHeadingBehavior(unittest.TestCase):
-    """ 
+    """
         The test loads and execute an altitude heading behavior.
         -   Load the mission altitude_heading_mission_test.xml
         -   Execute the mission
@@ -76,7 +76,6 @@ class TestAltitudeHeadingBehavior(unittest.TestCase):
 
     def altitude_heading_goal_callback(self, msg):
         self.altitude_heading_goal = msg
-        rospy.loginfo(msg)
 
     def test_mission_with_altitude_heading_behavior(self):
         self.mission.load_mission('altitude_heading_mission_test.xml')
@@ -85,23 +84,24 @@ class TestAltitudeHeadingBehavior(unittest.TestCase):
         altitude = self.mission.get_behavior_parameter('altitude')
         heading = self.mission.get_behavior_parameter('heading')
         speed_knots = self.mission.get_behavior_parameter('speed_knots')
-        enable_mask = 0
 
         # Calculate the mask
-        def get_mask(value, mask):
-            return mask if value else 0
-        enable_mask |= get_mask(altitude, AltitudeHeading.ALTITUDE_ENA)
-        enable_mask |= get_mask(heading, AltitudeHeading.HEADING_ENA)
-        enable_mask |= get_mask(speed_knots, AltitudeHeading.SPEED_KNOTS_ENA)
+        enable_mask = 0
+        if altitude is not None:
+            enable_mask |= AltitudeHeading.ALTITUDE_ENA
 
-        def check_parameter(value):
-            return value if value else 0
+        if heading is not None:
+            enable_mask |= AltitudeHeading.HEADING_ENA
+
+        if speed_knots is not None:
+            enable_mask |= AltitudeHeading.SPEED_KNOTS_ENA
 
         def altitude_heading_goals_are_set():
-            return (self.altitude_heading_goal.altitude == check_parameter(altitude) and
-                    self.altitude_heading_goal.heading == check_parameter(heading) and
-                    self.altitude_heading_goal.speed_knots == check_parameter(speed_knots) and
+            return ((altitude is None or self.altitude_heading_goal.altitude == float(altitude)) and
+                    (heading is None or self.altitude_heading_goal.heading == float(heading)) and
+                    (speed_knots is None or self.altitude_heading_goal.speed_knots == float(speed_knots)) and
                     self.altitude_heading_goal.ena_mask == enable_mask)
+
         self.assertTrue(wait_for(altitude_heading_goals_are_set),
                         msg='Mission control must publish goals')
 

--- a/mission_control/test/test_files/test_missions/altitude_heading_mission_test.xml
+++ b/mission_control/test/test_files/test_missions/altitude_heading_mission_test.xml
@@ -1,0 +1,10 @@
+ <!-- This file is used for testing  -->
+ 
+ <root main_tree_to_execute = "MainTree" >
+     <BehaviorTree ID="MainTree">
+        <Sequence name="mission test">
+            <AltitudeHeadingBehavior     altitude="1.0" heading="2.0" speed_knots="3.0" time_out="2.0" altitude_tol="10.0" heading_tol="10.0"/>
+        </Sequence>
+     </BehaviorTree>
+
+ </root>


### PR DESCRIPTION
# Description
This PR adds the altitude behavior to the mission control and modify the autopilot to work with it. 
- Modification to the autopilot.
- Create the altitude heading behavior test.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

Behavior tests wont pass. The behavior tests must change the parameter adquisition and the calculation of the Behavior::enable_mask

# How To Test
For testing launch the mission control
```sh
roslaunch mission_control mission_control.launch
```
and then the test
```sh
./test/test_altitude_heading_behavior.py
```