### PR TITLE
Fixed rudder behavior parameters

### DIFF
--- a/mission_control/include/mission_control/behaviors/fixed_rudder.h
+++ b/mission_control/include/mission_control/behaviors/fixed_rudder.h
@@ -41,11 +41,12 @@
 #include <behaviortree_cpp_v3/behavior_tree.h>
 #include <behaviortree_cpp_v3/bt_factory.h>
 #include <ros/ros.h>
+
 #include <string>
 
+#include "auv_interfaces/StateStamped.h"
 #include "mission_control/FixedRudder.h"
 #include "mission_control/behavior.h"
-#include "auv_interfaces/StateStamped.h"
 
 namespace mission_control
 {
@@ -58,23 +59,23 @@ class MoveWithFixedRudder : public Behavior
 
   static BT::PortsList providedPorts()
   {
-    BT::PortsList ports =
-    {
-      BT::InputPort<double>("depth", 0.0, "depth"),
-      BT::InputPort<double>("rudder", 0.0, "altitude"),
-      BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
-      BT::InputPort<double>("behavior_time", 0.0, "behavior_time"),
-      BT::InputPort<double>("rudder_tol", 0.0, "rudder_tol"),
-      BT::InputPort<double>("depth_tol", 0.0, "depth_tol"),
-      BT::InputPort<double>("altitude_tol", 0.0, "altitude_tol")
-    };
-    return ports;
+    return {BT::InputPort<double>("depth", "depth"),  //  NOLINT
+            BT::InputPort<double>("rudder", "altitude"),
+            BT::InputPort<double>("speed_knots", "speed_knots"),
+            BT::InputPort<double>("behavior_time", "behavior_time"),
+            BT::InputPort<double>("rudder_tol", 0.0, "rudder_tol"),
+            BT::InputPort<double>("depth_tol", 0.0, "depth_tol"),
+            BT::InputPort<double>("altitude_tol", 0.0, "altitude_tol")};
   }
 
  private:
+  void stateDataCallback(const auv_interfaces::StateStamped& data);
+  void publishGoalMsg();
+
   ros::NodeHandle nodeHandle_;
   ros::Publisher fixedRudderBehaviorPub_;
   ros::Subscriber subStateData_;
+  ros::Time behaviorStartTime_;
 
   double depth_;
   double altitude_;
@@ -91,10 +92,7 @@ class MoveWithFixedRudder : public Behavior
   double rudderTolerance_;
   double altitudeTolerance_;
 
-  void stateDataCallback(const auv_interfaces::StateStamped &data);
   bool goalHasBeenPublished_;
-  void publishGoalMsg();
-  ros::Time behaviorStartTime_;
 };
 
 }  //  namespace mission_control

--- a/mission_control/src/behaviors/fixed_rudder.cpp
+++ b/mission_control/src/behaviors/fixed_rudder.cpp
@@ -82,12 +82,13 @@ BT::NodeStatus MoveWithFixedRudder::behaviorRunningProcess()
     auto res = getInput<std::string>("behavior_time");
     if (!res)
     {
-      ROS_ERROR_STREAM("error reading port [command]:" << res.error());
+      ROS_ERROR_STREAM("error reading port [behavior_time]:" << res.error());
       setStatus(BT::NodeStatus::FAILURE);
     }
     else
     {
       getInput<double>("behavior_time", behaviorTime_);
+      behaviorStartTime_ = ros::Time::now();
       publishGoalMsg();
       goalHasBeenPublished_ = true;
     }
@@ -95,7 +96,11 @@ BT::NodeStatus MoveWithFixedRudder::behaviorRunningProcess()
   else
   {
     ros::Duration delta_t = ros::Time::now() - behaviorStartTime_;
-    if (delta_t.toSec() > behaviorTime_) setStatus(BT::NodeStatus::SUCCESS);
+    if (delta_t.toSec() > behaviorTime_)
+    {
+      setStatus(BT::NodeStatus::SUCCESS);
+      goalHasBeenPublished_ = false;
+    }
   }
   return (status());
 }


### PR DESCRIPTION
# Description

This PR introduces:
- Remove default parameters read from the mission file behavior ports
- Checks that behavior time is setted on the behavior parameter.
- Allow the behavior to be re-executed.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] fixed rudder behavior tests is passing
- [x] Linter tests are passing

# How To Test

For testing launch the mission control
```sh
roslaunch mission_control mission_control.launch
```
and then the test
```sh
./test/test_fixed_rudder_behavior.py
```