### PR TITLE
Change attitude servo behavior parameters - bt::ports

### DIFF
--- a/mission_control/include/mission_control/behaviors/attitude_servo.h
+++ b/mission_control/include/mission_control/behaviors/attitude_servo.h
@@ -41,11 +41,12 @@
 #include <behaviortree_cpp_v3/behavior_tree.h>
 #include <behaviortree_cpp_v3/bt_factory.h>
 #include <ros/ros.h>
+
 #include <string>
 
+#include "auv_interfaces/StateStamped.h"
 #include "mission_control/AttitudeServo.h"
 #include "mission_control/behavior.h"
-#include "auv_interfaces/StateStamped.h"
 
 namespace mission_control
 {
@@ -58,24 +59,24 @@ class AttitudeServoBehavior : public Behavior
 
   static BT::PortsList providedPorts()
   {
-    BT::PortsList ports =
-    {
-      BT::InputPort<double>("roll", 0.0, "roll"),
-      BT::InputPort<double>("pitch", 0.0, "pitch"),
-      BT::InputPort<double>("yaw", 0.0, "yaw"),
-      BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
-      BT::InputPort<double>("time_out", 0.0, "time_out"),
-      BT::InputPort<double>("roll_tol", 0.0, "roll_tol"),
-      BT::InputPort<double>("pitch_tol", 0.0, "pitch_tol"),
-      BT::InputPort<double>("yaw_tol", 0.0, "yaw_tol")
-    };
-    return ports;
+    return {BT::InputPort<double>("roll", "roll"),  //  NOLINT
+            BT::InputPort<double>("pitch", "pitch"),
+            BT::InputPort<double>("yaw", "yaw"),
+            BT::InputPort<double>("speed_knots", "speed_knots"),
+            BT::InputPort<double>("time_out", "time_out"),
+            BT::InputPort<double>("roll_tol", 0.0, "roll_tol"),
+            BT::InputPort<double>("pitch_tol", 0.0, "pitch_tol"),
+            BT::InputPort<double>("yaw_tol", 0.0, "yaw_tol")};
   }
 
  private:
+  void stateDataCallback(const auv_interfaces::StateStamped& data);
+  void publishGoalMsg();
+
   ros::NodeHandle nodeHandle_;
   ros::Publisher attitudeServoBehaviorPub_;
   ros::Subscriber subStateData_;
+  ros::Time behaviorStartTime_;
 
   double roll_;
   double pitch_;
@@ -87,15 +88,13 @@ class AttitudeServoBehavior : public Behavior
   bool pitchEnable_;
   bool yawEnable_;
   bool speedKnotsEnable_;
+  bool timeOutEnable_;
 
   double rollTolerance_;
   double pitchTolerance_;
   double yawTolerance_;
 
-  void stateDataCallback(const auv_interfaces::StateStamped& data);
   bool goalHasBeenPublished_;
-  void publishGoalMsg();
-  ros::Time behaviorStartTime_;
   bool behaviorComplete_;
 };
 

--- a/mission_control/src/behaviors/attitude_servo.cpp
+++ b/mission_control/src/behaviors/attitude_servo.cpp
@@ -92,19 +92,20 @@ BT::NodeStatus AttitudeServoBehavior::behaviorRunningProcess()
   }
   else
   {
-    ros::Duration delta_t = ros::Time::now() - behaviorStartTime_;
-    if (delta_t.toSec() > timeOut_ && timeOutEnable_)
+    if (timeOutEnable_)
     {
-      goalHasBeenPublished_ = false;
-      setStatus(BT::NodeStatus::FAILURE);
-    }
-    else
-    {
-      if (behaviorComplete_)
+      ros::Duration delta_t = ros::Time::now() - behaviorStartTime_;
+      if (delta_t.toSec() > timeOut_ && timeOutEnable_)
       {
-        setStatus(BT::NodeStatus::SUCCESS);
         goalHasBeenPublished_ = false;
+        setStatus(BT::NodeStatus::FAILURE);
+        return status();
       }
+    }
+    if (behaviorComplete_)
+    {
+      setStatus(BT::NodeStatus::SUCCESS);
+      goalHasBeenPublished_ = false;
     }
   }
   return status();


### PR DESCRIPTION
# Description
This PR removes default parameters read from the mission file behavior ports. 
Checks that behavior time is setted on the behavior parameter.

Fixes # (issue)
This PR also fixes the name of the topic to be subscribed ("/state"). This bug was introduced on #101

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Attitude servo Behavior test
- [x] Linter tests are passing

# How To Test
For testing launch the mission control
```sh
roslaunch mission_control mission_control.launch
```
and then the test
```sh
./test/test_attitude_servo_behavior.py
```