### PR TITLE
Change depth heading behavior parameters - bt::ports

### DIFF
--- a/mission_control/include/mission_control/behaviors/depth_heading.h
+++ b/mission_control/include/mission_control/behaviors/depth_heading.h
@@ -41,57 +41,57 @@
 #include <behaviortree_cpp_v3/behavior_tree.h>
 #include <behaviortree_cpp_v3/bt_factory.h>
 #include <ros/ros.h>
+
 #include <string>
 
+#include "auv_interfaces/StateStamped.h"
 #include "mission_control/DepthHeading.h"
 #include "mission_control/behavior.h"
-#include "auv_interfaces/StateStamped.h"
 
 namespace mission_control
 {
-  class DepthHeadingBehavior : public Behavior
+class DepthHeadingBehavior : public Behavior
+{
+ public:
+  DepthHeadingBehavior(const std::string &name, const BT::NodeConfiguration &config);
+
+  BT::NodeStatus behaviorRunningProcess();
+
+  static BT::PortsList providedPorts()
   {
-  public:
-    DepthHeadingBehavior(const std::string &name, const BT::NodeConfiguration &config);
+    return {BT::InputPort<double>("depth", "depth"),  //  NOLINT
+            BT::InputPort<double>("heading", "heading"),
+            BT::InputPort<double>("speed_knots", "speed_knots"),
+            BT::InputPort<double>("depth_tol", 0.0, "depth_tol"),
+            BT::InputPort<double>("heading_tol", 0.0, "heading_tol"),
+            BT::InputPort<double>("time_out", "time_out")};
+  }
 
-    BT::NodeStatus behaviorRunningProcess();
+ private:
+  void stateDataCallback(const auv_interfaces::StateStamped &data);
+  void publishGoalMsg();
 
-    static BT::PortsList providedPorts()
-    {
-      BT::PortsList ports =
-          {
-              BT::InputPort<double>("depth", 0.0, "depth"),
-              BT::InputPort<double>("heading", 0.0, "heading"),
-              BT::InputPort<double>("speed_knots", 0.0, "speed_knots"),
-              BT::InputPort<double>("depth_tol", 0.0, "depth_tol"),
-              BT::InputPort<double>("heading_tol", 0.0, "heading_tol"),
-              BT::InputPort<double>("time_out", 0.0, "time_out")};
-      return ports;
-    }
+  ros::NodeHandle nodeHandle_;
+  ros::Publisher depthHeadingBehaviorPub;
+  ros::Subscriber subCorrectedData_;
+  ros::Time behaviorStartTime_;
 
-  private:
-    ros::NodeHandle nodeHandle_;
-    ros::Publisher depthHeadingBehaviorPub;
-    ros::Subscriber subCorrectedData_;
+  double depth_;
+  double heading_;
+  double speedKnots_;
+  double timeOut_;
 
-    double depth_;
-    double heading_;
-    double speedKnots_;
-    double timeOut_;
+  bool depthEnable_;
+  bool headingEnable_;
+  bool speedKnotsEnable_;
+  bool timeOutEnable_;
 
-    bool depthEnable_;
-    bool headingEnable_;
-    bool speedKnotsEnable_;
+  double depthTolerance_;
+  double headingTolerance_;
 
-    double depthTolerance_;
-    double headingTolerance_;
-
-    void stateDataCallback(const auv_interfaces::StateStamped &data);
-    bool goalHasBeenPublished_;
-    void publishGoalMsg();
-    ros::Time behaviorStartTime_;
-    bool behaviorComplete_;
-  };
+  bool goalHasBeenPublished_;
+  bool behaviorComplete_;
+};
 
 }  //  namespace mission_control
 

--- a/mission_control/src/behaviors/depth_heading.cpp
+++ b/mission_control/src/behaviors/depth_heading.cpp
@@ -85,21 +85,23 @@ BT::NodeStatus DepthHeadingBehavior::behaviorRunningProcess()
   }
   else
   {
-    ros::Duration delta_t = ros::Time::now() - behaviorStartTime_;
-    if (delta_t.toSec() > timeOut_ && timeOutEnable_)
+    if (timeOutEnable_)
     {
-      goalHasBeenPublished_ = false;
-      setStatus(BT::NodeStatus::FAILURE);
-    }
-    else
-    {
-      if (behaviorComplete_)
+      ros::Duration delta_t = ros::Time::now() - behaviorStartTime_;
+      if (delta_t.toSec() > timeOut_ && timeOutEnable_)
       {
-        setStatus(BT::NodeStatus::SUCCESS);
         goalHasBeenPublished_ = false;
+        setStatus(BT::NodeStatus::FAILURE);
+        return status();
       }
     }
+    if (behaviorComplete_)
+    {
+      setStatus(BT::NodeStatus::SUCCESS);
+      goalHasBeenPublished_ = false;
+    }
   }
+
   return status();
 }
 


### PR DESCRIPTION
# Description
This PR removes default parameters read from the mission file behavior ports. 

Fixes # (issue)
This PR also fixes the name of the topic to be subscribed ("/state"). This bug was introduced on #101

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Depth Heading behavior test
- [x] Linter tests are passing

# How To Test
# How To Test
For testing launch the mission control
```sh
roslaunch mission_control mission_control.launch
```
and then the test
```sh
./test/test_depth_heading_behavior.py
```