### PR TITLE
Treat rates as frequency (not period) consistently.

### DIFF
--- a/fin_control/launch/fin_control.launch
+++ b/fin_control/launch/fin_control.launch
@@ -2,9 +2,9 @@
   <arg name="portName" default="/dev/ttyUSB0"/>
   <arg name="baudRate" default="3000000"/>
   <arg name="maxCtrlFinAngle" default="20.0"/>
-  <arg name="reportAngleRate" default="0.04"/>
-  <arg name="minReportAngleRate" default="0.02"/>
-  <arg name="maxReportAngleRate" default="0.08"/>
+  <arg name="reportAngleRate" default="25.0"/>
+  <arg name="minReportAngleRate" default="12.5"/>
+  <arg name="maxReportAngleRate" default="50.0"/>
   <arg name="currentLoggingEnabled" default="false"/>
 
   <node pkg="fin_control" type="fin_control_node" name="fin_control" output="screen">

--- a/fin_control/src/fin_control.cpp
+++ b/fin_control/src/fin_control.cpp
@@ -61,7 +61,7 @@ FinControl::FinControl(ros::NodeHandle &nodeHandle)
   servosON = false;
   const char *log;
   currentLoggingEnabled = false;
-  reportAngleRate = 0.04;
+  reportAngleRate = 25.0;
   minReportAngleRate = reportAngleRate / 2.0;
   maxReportAngleRate = reportAngleRate * 2.0;
 
@@ -104,7 +104,7 @@ FinControl::FinControl(ros::NodeHandle &nodeHandle)
       nodeHandle.advertise<fin_control::ReportAngle>("/fin_control/report_angle", 1);
 
   timer_reportAngle = nodeHandle.createTimer(
-      ros::Duration(reportAngleRate), &FinControl::reportAngleSendTimeout, this);
+      ros::Duration(1 ./ reportAngleRate), &FinControl::reportAngleSendTimeout, this);
 
   finAngleCheck = diagnostic_tools::create_health_check<double>(
       "Fin angle within range", [this](double angle) -> diagnostic_tools::Diagnostic

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -70,12 +70,12 @@ HealthMonitor::HealthMonitor(ros::NodeHandle &nodeHandle) : nodeHandle(nodeHandl
     nodeHandle.getParam("/health_monitor_node/max_report_faults_rate", maxReportFaultRate);
 
     ROS_INFO("Report Faults Rate:[%lf]", reportFaultsRate);
-    reportFaultsTimer = nodeHandle.createTimer(ros::Duration(reportFaultsRate),
+    reportFaultsTimer = nodeHandle.createTimer(ros::Duration(1. / reportFaultsRate),
                                                &HealthMonitor::reportFaultsTimeout, this);
 
     diagnostic_tools::PeriodicMessageStatusParams paramsReportsHealthMonitorCheckPeriod{};
-    paramsReportsHealthMonitorCheckPeriod.min_acceptable_period(minReportFaultRate);
-    paramsReportsHealthMonitorCheckPeriod.max_acceptable_period(maxReportFaultRate);
+    paramsReportsHealthMonitorCheckPeriod.min_acceptable_period(1. / maxReportFaultRate);
+    paramsReportsHealthMonitorCheckPeriod.max_acceptable_period(1. / minReportFaultRate);
     diagnosticsUpdater.add(publisher_reportFault.add_check<diagnostic_tools::PeriodicMessageStatus>(
         "rate check", paramsReportsHealthMonitorCheckPeriod));
 }

--- a/thruster_control/launch/thruster_control.launch
+++ b/thruster_control/launch/thruster_control.launch
@@ -1,11 +1,11 @@
 <launch>
 
-  <arg name="rpmRate" default="0.1"/>
-  <arg name="minRpmRate" default="0.05"/>
-  <arg name="maxRpmRate" default="0.2"/>
-  <arg name="tempRate" default="0.5"/>
-  <arg name="minTempRate" default="0.25"/>
-  <arg name="maxTempRate" default="1.0"/>
+  <arg name="rpmRate" default="10.0"/>
+  <arg name="minRpmRate" default="5.0"/>
+  <arg name="maxRpmRate" default="20.0"/>
+  <arg name="tempRate" default="2.0"/>
+  <arg name="minTempRate" default="1.0"/>
+  <arg name="maxTempRate" default="4.0"/>
   <arg name="motorTemperatureSteadyBand" default="0.0"/>
   <arg name="setRPMTimeout" default="0.5"/>
   <arg name="canNodeId1" default="0x07"/>

--- a/thruster_control/src/thruster_control.cpp
+++ b/thruster_control/src/thruster_control.cpp
@@ -182,8 +182,8 @@ ThrusterControl::ThrusterControl(ros::NodeHandle& nodeHandle)
   publisher_reportRPM = diagnostic_tools::create_publisher<thruster_control::ReportRPM>(
       nodeHandle, "/thruster_control/report_rpm", 1);
   diagnostic_tools::PeriodicMessageStatusParams paramsReportsRPMCheckPeriod{};
-  paramsReportsRPMCheckPeriod.min_acceptable_period(minReportRPMRate);
-  paramsReportsRPMCheckPeriod.max_acceptable_period(maxReportRPMRate);
+  paramsReportsRPMCheckPeriod.min_acceptable_period(1.0 / maxReportRPMRate);
+  paramsReportsRPMCheckPeriod.max_acceptable_period(1.0 / minReportRPMRate);
   diagnostic_tools::Diagnostic diagnosticRPMInfoStale(diagnostic_tools::Diagnostic::WARN,
                                                       ReportFault::THRUSTER_RPM_STALE);
   paramsReportsRPMCheckPeriod.abnormal_diagnostic(diagnosticRPMInfoStale);
@@ -194,8 +194,8 @@ ThrusterControl::ThrusterControl(ros::NodeHandle& nodeHandle)
       diagnostic_tools::create_publisher<thruster_control::ReportMotorTemperature>(
           nodeHandle, "/thruster_control/report_motor_temperature", 1);
   diagnostic_tools::PeriodicMessageStatusParams paramsReportsTemperatureCheckPeriod{};
-  paramsReportsTemperatureCheckPeriod.min_acceptable_period(minReportMotorTemperatureRate);
-  paramsReportsTemperatureCheckPeriod.max_acceptable_period(maxReportMotorTemperatureRate);
+  paramsReportsTemperatureCheckPeriod.min_acceptable_period(1. / maxReportMotorTemperatureRate);
+  paramsReportsTemperatureCheckPeriod.max_acceptable_period(1. / minReportMotorTemperatureRate);
   diagnostic_tools::Diagnostic diagnosticTemperatureInfoStale(diagnostic_tools::Diagnostic::WARN,
                                                               ReportFault::THRUSTER_TEMP_STALE);
   paramsReportsTemperatureCheckPeriod.abnormal_diagnostic(diagnosticTemperatureInfoStale);
@@ -250,12 +250,12 @@ ThrusterControl::ThrusterControl(ros::NodeHandle& nodeHandle)
 );
   diagnosticsUpdater.add(motorTemperatureCheck);
 
-  reportRPMTimer = nodeHandle.createTimer(ros::Duration(reportRPMRate),
+  reportRPMTimer = nodeHandle.createTimer(ros::Duration(1. / reportRPMRate),
                                           &ThrusterControl::reportRPMSendTimeout, this);
   reportMotorTempTimer = nodeHandle.createTimer(ros::Duration(reportMotorTemperatureRate),
                                                 &ThrusterControl::reportMotorTempSendTimeout, this);
   reportBatteryHealthTimer =
-      nodeHandle.createTimer(ros::Duration(reportBatteryHealthRate),
+      nodeHandle.createTimer(ros::Duration(1. / reportBatteryHealthRate),
                              &ThrusterControl::reportBatteryHealthSendTimeout, this);
   canIntf.Init();
 }


### PR DESCRIPTION
# Description

Precisely what the title says. Before this patch, there still were places treating rates as durations instead of frequencies, frequently leading to bad configuration.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

1. Run system testbed on a vehicle:

```sh
catkin_make run_tests_system_testbed
```