### PR TITLE
Add mission control pkg dependencies in mission logger

### DIFF
--- a/mission_logger/package.xml
+++ b/mission_logger/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslint</build_depend>
-  <exec_depend>mission_manager</exec_depend>
+  <exec_depend>mission_control</exec_depend>
   <exec_depend>rosgraph</exec_depend>
   <exec_depend>roslib</exec_depend>
   <exec_depend>rostopic</exec_depend>


### PR DESCRIPTION
# Description

## Fixes

This PR replace the mission manager pkg with mission logger pkg in the package.xml dependencies.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
