### PR TITLE
Add IntrospectableNode and ReactiveActionNode tests

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -103,6 +103,11 @@ install(DIRECTORY
 if(CATKIN_ENABLE_TESTING)
   roslint_add_test()
 
+  catkin_add_gtest(test_reactive_action test/test_reactive_action.cpp)
+  target_link_libraries(test_reactive_action ${PROJECT_NAME} ${catkin_LIBRARIES})
+  catkin_add_gtest(test_introspectable_node test/test_introspectable_node.cpp)
+  target_link_libraries(test_introspectable_node ${PROJECT_NAME} ${catkin_LIBRARIES})
+
   find_package(rostest REQUIRED)
   add_rostest(test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test)
   add_rostest(test/test_jaus_ros_bridge_interface_mission_control.test)

--- a/mission_control/include/mission_control/behaviors/fix_rudder.h
+++ b/mission_control/include/mission_control/behaviors/fix_rudder.h
@@ -45,7 +45,6 @@
 
 #include "auv_interfaces/StateStamped.h"
 
-#include "mission_control/behaviors/introspectable_action.h"
 
 namespace mission_control
 {

--- a/mission_control/include/mission_control/behaviors/payload_command.h
+++ b/mission_control/include/mission_control/behaviors/payload_command.h
@@ -44,7 +44,6 @@
 
 #include <string>
 
-#include "mission_control/behaviors/introspectable_action.h"
 
 namespace mission_control
 {

--- a/mission_control/include/mission_control/behaviors/reactive_action.h
+++ b/mission_control/include/mission_control/behaviors/reactive_action.h
@@ -68,12 +68,18 @@ public:
 
   void halt() override
   {
-    tearDown();
+    if (!isHalted())
+    {
+      tearDown();
+    }
     setStatus(BT::NodeStatus::IDLE);
   }
 
 private:
-  virtual BT::NodeStatus setUp() {}
+  virtual BT::NodeStatus setUp()
+  {
+    return BT::NodeStatus::RUNNING;
+  }
   virtual BT::NodeStatus doWork() = 0;
   virtual void tearDown() {}
 };

--- a/mission_control/package.xml
+++ b/mission_control/package.xml
@@ -39,4 +39,5 @@
   <exec_depend>std_msgs</exec_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/mission_control/src/behaviors/introspection.cpp
+++ b/mission_control/src/behaviors/introspection.cpp
@@ -45,14 +45,8 @@ static constexpr char ACTIVE_PATH_KEY[] = "introspection/active_path";
 std::string extendActivePath(BT::Blackboard* bb, const std::string& node)
 {
   std::string parent_path;
-  if (bb->get(ACTIVE_PATH_KEY, parent_path))
-    {
-      bb->set(ACTIVE_PATH_KEY, parent_path + "/" + node);
-    }
-  else
-    {
-      bb->set(ACTIVE_PATH_KEY, node);
-    }
+  bb->get(ACTIVE_PATH_KEY, parent_path);
+  bb->set(ACTIVE_PATH_KEY, parent_path + "/" + node);
   return parent_path;
 }
 
@@ -69,10 +63,7 @@ bool getActivePath(const BT::Blackboard* bb, std::string& path)
 std::string getActivePath(const BT::Blackboard* bb)
 {
   std::string path;
-  if (!getActivePath(bb, path))
-  {
-    path = "?";
-  }
+  getActivePath(bb, path);
   return path;
 }
 

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -46,7 +46,7 @@
 #include "mission_control/behaviors/set_altitude_heading.h"
 #include "mission_control/behaviors/set_depth_heading.h"
 
-#include "mission_control/behaviors/introspectable_action.h"
+#include "mission_control/behaviors/introspectable_node.h"
 
 #include <string>
 
@@ -69,13 +69,13 @@ class MissionBehaviorTreeFactory : public BT::BehaviorTreeFactory
   MissionBehaviorTreeFactory()
   {
     // TODO(hidmic): load behavior classes from ROS plugins
-    this->registerNodeType<IntrospectableActionNode<AbortNode>>("Abort");
-    this->registerNodeType<IntrospectableActionNode<AttitudeServoNode>>("AttitudeServo");
-    this->registerNodeType<IntrospectableActionNode<FixRudderNode>>("FixRudder");
-    this->registerNodeType<IntrospectableActionNode<GoToWaypointNode>>("GoToWaypoint");
-    this->registerNodeType<IntrospectableActionNode<PayloadCommandNode>>("PayloadCommand");
-    this->registerNodeType<IntrospectableActionNode<SetAltitudeHeadingNode>>("SetAltitudeHeading");
-    this->registerNodeType<IntrospectableActionNode<SetDepthHeadingNode>>("SetDepthHeading");
+    this->registerNodeType<IntrospectableNode<AbortNode>>("Abort");
+    this->registerNodeType<IntrospectableNode<AttitudeServoNode>>("AttitudeServo");
+    this->registerNodeType<IntrospectableNode<FixRudderNode>>("FixRudder");
+    this->registerNodeType<IntrospectableNode<GoToWaypointNode>>("GoToWaypoint");
+    this->registerNodeType<IntrospectableNode<PayloadCommandNode>>("PayloadCommand");
+    this->registerNodeType<IntrospectableNode<SetAltitudeHeadingNode>>("SetAltitudeHeading");
+    this->registerNodeType<IntrospectableNode<SetDepthHeadingNode>>("SetDepthHeading");
   }
 };
 

--- a/mission_control/test/test_introspectable_node.cpp
+++ b/mission_control/test/test_introspectable_node.cpp
@@ -1,0 +1,135 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "mission_control/behaviors/introspectable_node.h"
+#include "mission_control/behaviors/introspection.h"
+
+
+namespace mission_control
+{
+namespace
+{
+
+class SimpleIntrospectableActionNode :
+    public IntrospectableNode<BT::ActionNodeBase>
+{
+public:
+  using TickFunction =
+      std::function<BT::NodeStatus(BT::TreeNode&)>;
+
+  SimpleIntrospectableActionNode(
+      const std::string& name,
+      const TickFunction& tick_function,
+      const BT::NodeConfiguration& config)
+    : IntrospectableNode<BT::ActionNodeBase>(name, config),
+      tick_function_(tick_function)
+  {
+  }
+
+  void halt() override
+  {
+    setStatus(BT::NodeStatus::IDLE);
+  }
+
+protected:
+  BT::NodeStatus tick() override
+  {
+    return tick_function_(*this);
+  }
+
+private:
+  TickFunction tick_function_;
+};
+
+TEST(TestIntrospectableActionNode, nominal)
+{
+  BT::Tree tree;
+  BT::Blackboard::Ptr bb = BT::Blackboard::create();
+  tree.blackboard_stack.push_back(bb);
+  BT::NodeConfiguration config;
+  config.blackboard = bb;
+  auto chat =
+    std::make_shared<IntrospectableNode<BT::SequenceNode>>("chat", config);
+  tree.nodes.push_back(chat);
+  auto say_hi =
+    std::make_shared<SimpleIntrospectableActionNode>(
+      "say_hi",
+      [](BT::TreeNode& node)
+      {
+        if (node.status() == BT::NodeStatus::RUNNING)
+        {
+          return BT::NodeStatus::SUCCESS;
+        }
+        std::cout << "hi" << std::endl;
+        return BT::NodeStatus::RUNNING;
+      }, config);  // NOLINT
+  chat->addChild(say_hi.get());
+  tree.nodes.push_back(say_hi);
+  auto say_bye =
+    std::make_shared<SimpleIntrospectableActionNode>(
+      "say_bye",
+      [](BT::TreeNode& node)
+      {
+        if (node.status() == BT::NodeStatus::RUNNING)
+        {
+          return BT::NodeStatus::SUCCESS;
+        }
+        std::cout << "bye" << std::endl;
+        return BT::NodeStatus::RUNNING;
+      }, config);  // NOLINT
+  chat->addChild(say_bye.get());
+  tree.nodes.push_back(say_bye);
+
+  EXPECT_EQ(introspection::getActivePath(tree), "");
+  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::RUNNING);
+  EXPECT_EQ(introspection::getActivePath(tree), "/chat/say_hi");
+  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::RUNNING);
+  EXPECT_EQ(introspection::getActivePath(tree), "/chat/say_bye");
+  EXPECT_EQ(tree.tickRoot(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(introspection::getActivePath(tree), "");
+}
+
+}  // namespace
+}  // namespace mission_control
+
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/mission_control/test/test_reactive_action.cpp
+++ b/mission_control/test/test_reactive_action.cpp
@@ -1,0 +1,136 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "mission_control/behaviors/reactive_action.h"
+
+
+namespace mission_control
+{
+namespace
+{
+class ReactiveCountDownNode : public ReactiveActionNode
+{
+public:
+  explicit ReactiveCountDownNode(size_t start_count)
+    : ReactiveActionNode("countdown", {}), // NOLINT
+      start_count_(start_count)
+  {
+  }
+
+  bool wasSetUp() const { return setUp_; }
+
+  bool wasTornDown() const { return tornDown_; }
+
+private:
+  BT::NodeStatus setUp() override
+  {
+    if (start_count_ == 0u)
+    {
+      return BT::NodeStatus::SUCCESS;
+    }
+    setUp_ = true;
+    current_count_ = start_count_;
+    return BT::NodeStatus::RUNNING;
+  }
+
+  BT::NodeStatus doWork() override
+  {
+    return --current_count_ == 0u ?
+      BT::NodeStatus::SUCCESS :
+      BT::NodeStatus::RUNNING;
+  }
+
+  void tearDown() override
+  {
+    tornDown_ = true;
+  }
+
+  const size_t start_count_;
+  size_t current_count_;
+  bool tornDown_{false};
+  bool setUp_{false};
+};
+
+TEST(TestReactiveActionNode, immediate_success)
+{
+  ReactiveCountDownNode root(0);
+  BT::NodeStatus status = root.executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(root.wasSetUp());
+  EXPECT_FALSE(root.wasTornDown());
+}
+
+TEST(TestReactiveActionNode, nominal)
+{
+  ReactiveCountDownNode root(1);
+  BT::NodeStatus status = root.executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_TRUE(root.wasSetUp());
+  EXPECT_FALSE(root.wasTornDown());
+  status = root.executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);
+  EXPECT_TRUE(root.wasTornDown());
+}
+
+TEST(TestReactiveActionNode, halt_while_idle)
+{
+  ReactiveCountDownNode root(1u);
+  root.halt();
+  EXPECT_EQ(root.status(), BT::NodeStatus::IDLE);
+  EXPECT_FALSE(root.wasSetUp());
+  EXPECT_FALSE(root.wasTornDown());
+}
+
+TEST(TestReactiveActionNode, halt)
+{
+  ReactiveCountDownNode root(1u);
+  BT::NodeStatus status = root.executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_TRUE(root.wasSetUp());
+  EXPECT_FALSE(root.wasTornDown());
+  root.halt();
+  EXPECT_EQ(root.status(), BT::NodeStatus::IDLE);
+  EXPECT_TRUE(root.wasTornDown());
+}
+
+}  // namespace
+}  // namespace mission_control
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Description


This patch adds a few missing unit tests in the `mission_control` package. It also fixes / adjusts some of the relevant implementation details.


## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Run `mission_control` unit tests:
```sh
catkin_make run_tests_mission_control
```