### PR TITLE
Fix isolated package builds

### DIFF
--- a/jaus_ros_bridge/CMakeLists.txt
+++ b/jaus_ros_bridge/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   message_generation
   mission_control
+  payload_manager
   thruster_control
   health_monitor
   fin_control

--- a/jaus_ros_bridge/package.xml
+++ b/jaus_ros_bridge/package.xml
@@ -58,6 +58,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>fin_control</build_depend>
+  <build_depend>payload_manager</build_depend>
   <build_depend>thruster_control</build_depend>
   <build_depend>mission_control</build_depend>
   <build_depend>message_generation</build_depend>
@@ -77,6 +78,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>fin_control</exec_depend>
+  <exec_depend>payload_manager</exec_depend>
   <exec_depend>thruster_control</exec_depend>
   <exec_depend>mission_control</exec_depend>
   <exec_depend>message_runtime</exec_depend>

--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   geodesy
   health_monitor
   message_generation
+  payload_manager
   roscpp
   roslint
   rospy
@@ -38,13 +39,12 @@ add_message_files(
 
 generate_messages(
   DEPENDENCIES
-  payload_manager
   std_msgs
 )
 
 catkin_package(
  INCLUDE_DIRS include
- CATKIN_DEPENDS auv_interfaces payload_manager health_monitor roscpp rospy std_msgs
+ CATKIN_DEPENDS auv_interfaces health_monitor roscpp rospy std_msgs
 )
 
 ###########

--- a/mission_control/include/mission_control/mission_control.h
+++ b/mission_control/include/mission_control/mission_control.h
@@ -41,21 +41,15 @@
 #ifndef MISSION_CONTROL_MISSION_CONTROL_H
 #define MISSION_CONTROL_MISSION_CONTROL_H
 
-#include <behaviortree_cpp_v3/action_node.h>
-#include <behaviortree_cpp_v3/bt_factory.h>
 #include <dirent.h>
 #include <ros/ros.h>
 #include <stdint.h>
 
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/thread.hpp>
-#include <map>
 #include <string>
 #include <memory>
+#include <unordered_map>
 
 #include "health_monitor/ReportFault.h"
-#include "jaus_ros_bridge/ActivateManualControl.h"
 #include "mission_control/AbortMission.h"
 #include "mission_control/ExecuteMission.h"
 #include "mission_control/LoadMission.h"

--- a/mission_control/package.xml
+++ b/mission_control/package.xml
@@ -22,7 +22,6 @@
   <build_depend>std_msgs</build_depend>
   <build_export_depend>auv_interfaces</build_export_depend>
   <build_export_depend>health_monitor</build_export_depend>
-  <build_export_depend>payload_manager</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>


### PR DESCRIPTION
# Description

This patch fixes several CMakeLists.txt and package.xml files for the workspace to build in isolation (e.g. when cross-compiling). We did not notice before because regular builds tend to obscure this kind of issues.

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Build a clean workspace with `catkin_make_isolated`