### PR TITLE
Use radians consistently

### DIFF
--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -96,6 +96,7 @@ AutoPilotNode::AutoPilotNode(ros::NodeHandle& node_handle) : nh(node_handle)
   nh.param<double>("/autopilot_node/depth_imax", depthIMax, 0.0);
   nh.param<double>("/autopilot_node/depth_imin", depthIMin, 0.0);
   nh.param<double>("/autopilot_node/depth_d", depthDGain, 0.0);
+  nh.param<double>("/autopilot_node/max_depth_command", maxDepthCommand, 10.0);
 
   nh.param<double>("/autopilot_node/altitude_p", altitudePGain, 1.0);
   nh.param<double>("/autopilot_node/altitude_i", altitudeIGain, 0.0);
@@ -104,10 +105,8 @@ AutoPilotNode::AutoPilotNode(ros::NodeHandle& node_handle) : nh(node_handle)
   nh.param<double>("/autopilot_node/altitude_d", altitudeDGain, 0.0);
   nh.param<double>("/autopilot_node/max_altitude_command",maxAltitudeCommand, 25.0);
 
-  double maxCtrlFinAngleInRadians = degreesToRadians(10.0);
-  nh.param<double>("/fin_control/max_ctrl_fin_angle", maxCtrlFinAngleInRadians);
-  maxCtrlFinAngle = radiansToDegrees(maxCtrlFinAngle);  // degrees
-  nh.param<double>("/autopilot_node/max_depth_command", maxDepthCommand, 10.0);
+  maxCtrlFinAngle = radiansToDegrees(
+    nh.param<double>("/fin_control/max_ctrl_fin_angle", degreesToRadians(10.0)));
 
   rollPIDController.initPid(rollPGain, rollIGain, rollDGain, rollIMax, rollIMin);
   pitchPIDController.initPid(pitchPGain, rollIGain, pitchDGain, pitchIMax, pitchIMin);

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -36,6 +36,16 @@
 
 #include "autopilot/autopilot.h"
 
+
+namespace
+{
+
+  double radiansToDegrees(double radians) { return (radians * (180.0 / M_PI)); }
+
+  double degreesToRadians(double degrees) { return ((degrees / 180.0) * M_PI); }
+
+}  // namespace
+
 AutoPilotNode::AutoPilotNode(ros::NodeHandle& node_handle) : nh(node_handle)
 {
   autoPilotInControl = false;
@@ -94,9 +104,10 @@ AutoPilotNode::AutoPilotNode(ros::NodeHandle& node_handle) : nh(node_handle)
   nh.param<double>("/autopilot_node/altitude_d", altitudeDGain, 0.0);
   nh.param<double>("/autopilot_node/max_altitude_command",maxAltitudeCommand, 25.0);
 
-
-  nh.param<double>("/fin_control/max_ctrl_fin_angle", maxCtrlFinAngle, 10.0);  // degrees
-  nh.param<double>("/autopilot_node/max_depth_command", maxDepthCommand, 10.0);       // degrees
+  double maxCtrlFinAngleInRadians = degreesToRadians(10.0);
+  nh.param<double>("/fin_control/max_ctrl_fin_angle", maxCtrlFinAngleInRadians);
+  maxCtrlFinAngle = radiansToDegrees(maxCtrlFinAngle);  // degrees
+  nh.param<double>("/autopilot_node/max_depth_command", maxDepthCommand, 10.0);
 
   rollPIDController.initPid(rollPGain, rollIGain, rollDGain, rollIMax, rollIMin);
   pitchPIDController.initPid(pitchPGain, rollIGain, pitchDGain, pitchIMax, pitchIMin);
@@ -169,15 +180,6 @@ void AutoPilotNode::missionMgrHeartbeatTimeout(const ros::TimerEvent& timer)
     thrusterPub.publish(setRPM);
   }
 }
-
-namespace
-{
-
-double radiansToDegrees(double radians) { return (radians * (180.0 / M_PI)); }
-
-double degreesToRadians(double degrees) { return ((degrees / 180.0) * M_PI); }
-
-}  // namespace
 
 void AutoPilotNode::stateCallback(const auv_interfaces::StateStamped& msg)
 {
@@ -294,15 +296,15 @@ void AutoPilotNode::attitudeServoCallback(const mission_control::AttitudeServo& 
   fixedRudder = true;  // this equate to fixed rudder with roll and pitch commands.
 
   ROS_INFO("Angle for roll: [%f]", msg.roll);
-  desiredRoll = msg.roll;
+  desiredRoll = radiansToDegrees(msg.roll);
 
   ROS_INFO("Angle for pitch: [%f]", msg.pitch);
-  desiredPitch = msg.pitch;
+  desiredPitch = radiansToDegrees(msg.pitch);
   depthControl = false;  // disable depth control setting pitch instead
   altitudeControl = false;
 
   ROS_INFO("Angle for yaw: [%f]", msg.yaw);
-  desiredRudder = msg.yaw;  // yaw in attitude servo is really a fixedrudder
+  desiredRudder = radiansToDegrees(msg.yaw);  // yaw in attitude servo is really a fixedrudder
 
   ROS_INFO("speed_knots: [%f]", msg.speed_knots);
 
@@ -323,7 +325,7 @@ void AutoPilotNode::depthHeadingCallback(const mission_control::DepthHeading& ms
   altitudeControl = false;
 
   ROS_INFO("Angle for yaw: [%f]", msg.heading);
-  desiredYaw = msg.heading;
+  desiredYaw = radiansToDegrees(msg.heading);
 
   ROS_INFO("speed_knots: [%f]", msg.speed_knots);
   desiredSpeed = msg.speed_knots;
@@ -344,7 +346,7 @@ void AutoPilotNode::altitudeHeadingCallback(const mission_control::AltitudeHeadi
   altitudeControl = true;  // enable altitude control;
  
   ROS_INFO("Angle for yaw: [%f]", msg.heading);
-  desiredYaw = msg.heading;
+  desiredYaw = radiansToDegrees(msg.heading);
   ROS_INFO("speed_knots: [%f]", msg.speed_knots);
   desiredSpeed = msg.speed_knots;
 }
@@ -363,7 +365,7 @@ void AutoPilotNode::fixedRudderCallback(const mission_control::FixedRudder& msg)
   altitudeControl = false;
 
   ROS_INFO("Angle for rudder: [%f]", msg.rudder);
-  desiredRudder = msg.rudder;
+  desiredRudder = radiansToDegrees(msg.rudder);
 
   ROS_INFO("speed_knots: [%f]", msg.speed_knots);
   desiredSpeed = msg.speed_knots;

--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -84,7 +84,6 @@ class FinControl
 
   void reportAngles();
 
-  float radiansToDegrees(float radians);
   float degreesToRadians(float degrees);
 
   void reportAngleSendTimeout(const ros::TimerEvent& ev);

--- a/fin_control/launch/fin_control.launch
+++ b/fin_control/launch/fin_control.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="portName" default="/dev/ttyUSB0"/>
   <arg name="baudRate" default="3000000"/>
-  <arg name="maxCtrlFinAngle" default="20.0"/>
+  <arg name="maxCtrlFinAngle" default="$(eval radians(20.0))"/>
   <arg name="reportAngleRate" default="25.0"/>
   <arg name="minReportAngleRate" default="12.5"/>
   <arg name="maxReportAngleRate" default="50.0"/>
@@ -11,7 +11,7 @@
     <param name="port" type="string" value="$(arg portName)" />
     <param name="baud" type="int" value="$(arg baudRate)" />
     <param name="max_ctrl_fin_angle" type="double" value="$(arg maxCtrlFinAngle)" />
-    <param name="ctrl_fin_offset" type="double" value="90.0" />
+    <param name="ctrl_fin_offset" type="double" value="$(eval radians(90.0))" />
     <param name="ctrl_fin_scale_factor" type="double" value="-1.0" />
     <param name="current_logging_enabled" type="boolean" value="$(arg currentLoggingEnabled)" />
     <param name="report_angle_rate" type="double" value="$(arg reportAngleRate)" />

--- a/mission_control/groot_palette/mission_control_behaviors_palette.xml
+++ b/mission_control/groot_palette/mission_control_behaviors_palette.xml
@@ -1,42 +1,48 @@
 <root>
     <TreeNodesModel>
         <Action ID="AttitudeServo">
-            <input_port name="pitch">Pitch angle to reach, in radians</input_port>
-            <input_port name="pitch_tol" default="0.0">Tolerance for pitch angle goal, in radians</input_port>
-            <input_port name="roll">Roll angle to reach, in radians</input_port>
-            <input_port name="roll_tol" default="0.0">Tolerance for roll angle goal, in radians</input_port>
-            <input_port name="speed_knots">Cruise speed to command, in knots</input_port>
-            <input_port name="yaw">Yaw angle to reach, in radians</input_port>
-            <input_port name="yaw_tol" default="0.0">Tolerance for yaw angle goal, in radians</input_port>
+            <input_port name="pitch" default="NaN">Pitch angle to reach</input_port>
+            <input_port name="pitch-tolerance" default="0.0">Tolerance for pitch</input_port>
+            <input_port name="pitch-units" default="radians">Units for pitch (supported units are: radians, degrees)</input_port>
+            <input_port name="roll" default="NaN">Roll angle to reach</input_port>
+            <input_port name="roll-tolerance" default="0.0">Tolerance for roll</input_port>
+            <input_port name="roll-units" default="radians">Units for roll (supported units are: radians, degrees)</input_port>
+            <input_port name="yaw" default="NaN">Yaw angle to reach</input_port>
+            <input_port name="yaw-tolerance" default="0.0">Tolerance for yaw</input_port>
+            <input_port name="yaw-units" default="radians">Units for yaw (supported units are: radians, degrees)</input_port>
+            <input_port name="speed_knots" default="NaN">Cruise speed to command, in knots</input_port>
         </Action>
         <Action ID="FixRudder">
-            <input_port name="depth">Rudder angle, in radians</input_port>
-            <input_port name="rudder">Depth to reach (positive down), in meters</input_port>
-            <input_port name="speed_knots">Cruise speed to command, in knots</input_port>
+            <input_port name="rudder" default="NaN">Rudder angle to fix</input_port>
+            <input_port name="rudder-units" default="radians">Units for rudder (supported units are: radians, degrees)</input_port>
+            <input_port name="depth" default="NaN">Depth to reach (positive down), in meters</input_port>
+            <input_port name="speed_knots" default="NaN">Cruise speed to command, in knots</input_port>
         </Action>
         <Action ID="GoToWaypoint">
-            <input_port name="altitude">Waypoint altitude (positive up), in meters</input_port>
-            <input_port name="depth">Waypoint depth (positive down), in meters</input_port>
+            <input_port name="altitude" default="NaN">Waypoint altitude (positive up), in meters</input_port>
+            <input_port name="depth" default="NaN">Waypoint depth (positive down), in meters</input_port>
             <input_port name="latitude">Waypoint latitude, in degrees</input_port>
             <input_port name="longitude">Waypoint longitude, in degrees</input_port>
-            <input_port name="speed_knots">Cruise speed to command, in knots</input_port>
+            <input_port name="speed_knots" default="NaN">Cruise speed to command, in knots</input_port>
             <input_port name="tolerance_radius" default="0.0">Radius of the tolerance sphere</input_port>
         </Action>
         <Action ID="PayloadCommand">
             <input_port name="command">Command to be sent to payload</input_port>
         </Action>
         <Action ID="SetAltitudeHeading">
-            <input_port name="altitude">Altitude to reach (positive up), in meters</input_port>
-            <input_port name="altitude_tol" default="0.0">Tolerance for altitude goal, in meters</input_port>
-            <input_port name="heading">Heading (or yaw) to reach, in radians</input_port>
-            <input_port name="heading_tol" default="0.0">Tolerance for heading goal, in radians</input_port>
+            <input_port name="altitude" default="NaN">Altitude to reach (positive up), in meters</input_port>
+            <input_port name="altitude-tolerance" default="0.0">Tolerance for altitude goal, in meters</input_port>
+            <input_port name="heading" default="NaN">Heading (or yaw) to reach</input_port>
+            <input_port name="heading-units" default="radians">Units for heading (supported units are: radians, degrees)</input_port>
+            <input_port name="heading-tolerance" default="0.0">Tolerance for heading</input_port>
             <input_port name="speed_knots">Cruise speed to command, in knots</input_port>
         </Action>
         <Action ID="SetDepthHeading">
-            <input_port name="depth">Depth to reach (positive down), in meters</input_port>
-            <input_port name="depth_tol" default="0.0">Tolerance for depth goal, in meters</input_port>
-            <input_port name="heading">Heading (or yaw) to reach, in radians</input_port>
-            <input_port name="heading_tol" default="0.0">Tolerance for heading goal, in radians</input_port>
+            <input_port name="depth" default="NaN">Depth to reach (positive down), in meters</input_port>
+            <input_port name="depth-tolerance" default="0.0">Tolerance for depth goal, in meters</input_port>
+            <input_port name="heading" default="NaN">Heading (or yaw) to reach</input_port>
+            <input_port name="heading-units" default="radians">Units for heading (supported units are: radians, degrees)</input_port>
+            <input_port name="heading-tolerance" default="0.0">Tolerance for heading</input_port>
             <input_port name="speed_knots">Cruise speed to command, in knots</input_port>
         </Action>
     </TreeNodesModel>

--- a/mission_control/include/mission_control/behaviors/attitude_servo.h
+++ b/mission_control/include/mission_control/behaviors/attitude_servo.h
@@ -45,7 +45,9 @@
 #include <string>
 
 #include "auv_interfaces/StateStamped.h"
+#include "mission_control/behaviors/helpers.h"
 #include "mission_control/behaviors/reactive_action.h"
+
 
 namespace mission_control
 {
@@ -56,13 +58,14 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {BT::InputPort<double>("roll", "Roll angle to reach, in radians"),  //  NOLINT
-            BT::InputPort<double>("pitch", "Pitch angle to reach, in radians"),
-            BT::InputPort<double>("yaw", "Yaw angle to reach, in radians"),
-            BT::InputPort<double>("speed_knots", "Cruise speed to command, in knots"),
-            BT::InputPort<double>("roll_tol", 0.0, "Tolerance for roll angle goal, in radians"),
-            BT::InputPort<double>("pitch_tol", 0.0, "Tolerance for pitch angle goal, in radians"),
-            BT::InputPort<double>("yaw_tol", 0.0, "Tolerance for yaw angle goal, in radians")};
+    return MakePortsList(
+      InputPort<double, HasTolerance, HasAngleUnits>(
+        "roll", NAN, "Roll angle to reach"),
+      InputPort<double, HasTolerance, HasAngleUnits>(
+        "pitch", NAN, "Pitch angle to reach"),
+      InputPort<double, HasTolerance, HasAngleUnits>(
+        "yaw", NAN, "Yaw angle to reach"),
+      BT::InputPort<double>("speed_knots", NAN, "Cruise speed to command, in knots"));
   }
 
 private:

--- a/mission_control/include/mission_control/behaviors/fix_rudder.h
+++ b/mission_control/include/mission_control/behaviors/fix_rudder.h
@@ -44,6 +44,7 @@
 #include <string>
 
 #include "auv_interfaces/StateStamped.h"
+#include "mission_control/behaviors/helpers.h"
 
 
 namespace mission_control
@@ -56,9 +57,10 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {BT::InputPort<double>("rudder", "Rudder angle, in radians"),  // NOLINT
-            BT::InputPort<double>("depth", "Depth to reach (positive down), in meters"),
-            BT::InputPort<double>("speed_knots", "Cruise speed to command, in knots")};
+    return MakePortsList(
+      InputPort<double, HasAngleUnits>("rudder", NAN, "Rudder angle"),
+      BT::InputPort<double>("depth", NAN, "Depth to reach (positive down), in meters"),
+      BT::InputPort<double>("speed_knots", NAN, "Cruise speed to command, in knots"));
   }
 
 protected:

--- a/mission_control/include/mission_control/behaviors/go_to_waypoint.h
+++ b/mission_control/include/mission_control/behaviors/go_to_waypoint.h
@@ -59,11 +59,11 @@ public:
   static BT::PortsList providedPorts()
   {
     return {  // NOLINT
-      BT::InputPort<double>("depth", "Waypoint depth (positive down), in meters"),
-      BT::InputPort<double>("altitude", "Waypoint altitude (positive up), in meters"),
-      BT::InputPort<double>("latitude", "Waypoint latitude, in degrees"),
-      BT::InputPort<double>("longitude", "Waypoint longitude, in degrees"),
-      BT::InputPort<double>("speed_knots", "Cruise speed to command, in knots"),
+      BT::InputPort<double>("depth", NAN, "Waypoint depth (positive down), in meters"),
+      BT::InputPort<double>("altitude", NAN, "Waypoint altitude (positive up), in meters"),
+      BT::InputPort<double>("latitude", NAN, "Waypoint latitude, in degrees"),
+      BT::InputPort<double>("longitude", NAN, "Waypoint longitude, in degrees"),
+      BT::InputPort<double>("speed_knots", NAN, "Cruise speed to command, in knots"),
       BT::InputPort<double>("tolerance_radius", 0.0, "Radius of the tolerance sphere "
                             "for UTM coordinates, in meters")};  // NOLINT
   }

--- a/mission_control/include/mission_control/behaviors/helpers.h
+++ b/mission_control/include/mission_control/behaviors/helpers.h
@@ -38,6 +38,7 @@
 #include <behaviortree_cpp_v3/basic_types.h>
 #include <behaviortree_cpp_v3/tree_node.h>
 
+#include <string>
 #include <utility>
 
 
@@ -59,14 +60,14 @@ UpdatePortsList(
 inline
 bool
 UpdatePortsList(
-  BT::PortsList::value_type&& input,
+  BT::PortsList::value_type&& input,  // NOLINT
   BT::PortsList* output)
 {
   output->insert(input).second;
 }
 
 template<typename...Args>
-void expand(Args&&...)
+void expand(Args&&...)  // NOLINT
 {
 }
 
@@ -74,7 +75,7 @@ void expand(Args&&...)
 
 template<typename...Args>
 BT::PortsList
-MakePortsList(Args&&... ports)
+MakePortsList(Args&&... ports)  // NOLINT
 {
   BT::PortsList list;
   internal::expand(internal::UpdatePortsList(

--- a/mission_control/include/mission_control/behaviors/helpers.h
+++ b/mission_control/include/mission_control/behaviors/helpers.h
@@ -1,0 +1,216 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef MISSION_CONTROL_BEHAVIORS_HELPERS_H
+#define MISSION_CONTROL_BEHAVIORS_HELPERS_H
+
+#include <behaviortree_cpp_v3/basic_types.h>
+#include <behaviortree_cpp_v3/tree_node.h>
+
+#include <utility>
+
+
+namespace mission_control
+{
+namespace internal
+{
+
+inline
+bool
+UpdatePortsList(
+  const BT::PortsList& input,
+  BT::PortsList* output)
+{
+  output->insert(input.begin(), input.end());
+  return true;
+}
+
+inline
+bool
+UpdatePortsList(
+  BT::PortsList::value_type&& input,
+  BT::PortsList* output)
+{
+  output->insert(input).second;
+}
+
+template<typename...Args>
+void expand(Args&&...)
+{
+}
+
+}  // namespace internal
+
+template<typename...Args>
+BT::PortsList
+MakePortsList(Args&&... ports)
+{
+  BT::PortsList list;
+  internal::expand(internal::UpdatePortsList(
+    std::forward<Args>(ports), &list)...);
+  return list;
+}
+
+template<typename T>
+struct HasTolerance
+{
+  static
+  BT::PortsList::value_type
+  InputPort(BT::StringView name)
+  {
+    return BT::InputPort<T>(
+      BT::StrCat(name, "-tolerance"), T{0},
+      BT::StrCat("Tolerance for ", name));
+  }
+};
+
+template<typename T>
+struct HasAngleUnits
+{
+  static
+  BT::PortsList::value_type
+  InputPort(BT::StringView name)
+  {
+    return BT::InputPort<std::string>(
+      BT::StrCat(name, "-units"), "radians",
+      BT::StrCat("Units for ", name, " angle ",
+                 "(supported units are: radians, degrees)"));
+  }
+
+  static
+  BT::Result
+  applyToInputValue(
+    BT::TreeNode* node,
+    const std::string& key,
+    T& value)
+  {
+    std::string units;
+    BT::Result result =
+      node->getInput<std::string>(
+        key + "-units", units);
+    if (result)
+    {
+      if ("degrees" == units)
+      {
+        value *= M_PI / 180.0;
+      }
+      else if ("radians" != units)
+      {
+        result = nonstd::make_unexpected(
+          "Angle unit '" + units + "' is unknown " +
+          "(supported units are: radians, degrees)");
+      }
+    }
+    return result;
+  }
+};
+
+template<typename T, template <typename> class...Traits>
+BT::PortsList
+InputPort(
+  BT::StringView name,
+  BT::StringView description)
+{
+  return MakePortsList(
+    BT::InputPort(name, description),
+    Traits<T>::InputPort(name)...);
+}
+
+template<typename T, template <typename> class...Traits>
+BT::PortsList
+InputPort(
+  BT::StringView name,
+  const T& default_value,
+  BT::StringView description)
+{
+  return MakePortsList(
+    BT::InputPort(name, default_value, description),
+    Traits<T>::InputPort(name)...);
+}
+
+template <typename T>
+BT::Result getInputValue(
+  BT::TreeNode* node,
+  const std::string& key,
+  T& value)
+{
+  return node->getInput<T>(key, value);
+}
+
+template <
+  typename T,
+  template <typename> class Trait,
+  template <typename> class...Others>
+BT::Result getInputValue(
+  BT::TreeNode* node,
+  const std::string& key,
+  T& value)
+{
+  BT::Result result = getInputValue<T, Others...>(node, key, value);
+  if (result)
+  {
+    result = Trait<T>::applyToInputValue(node, key, value);
+  }
+  return result;
+}
+
+template <typename T>
+BT::Result getInputTolerance(
+    BT::TreeNode* node,
+    const std::string& key,
+    T& tolerance)
+{
+  return node->getInput<T>(key + "-tolerance", tolerance);
+}
+
+template <
+  typename T,
+  template <typename> class Trait,
+  template <typename> class...Others>
+BT::Result getInputTolerance(
+  BT::TreeNode* node,
+  const std::string& key,
+  T& tolerance)
+{
+  BT::Result result = getInputTolerance<T, Others...>(node, key, tolerance);
+  if (result)
+  {
+    result = Trait<T>::applyToInputValue(node, key, tolerance);
+  }
+  return result;
+}
+
+}  // namespace mission_control
+
+#endif  // MISSION_CONTROL_BEHAVIORS_HELPERS_H

--- a/mission_control/include/mission_control/behaviors/set_altitude_heading.h
+++ b/mission_control/include/mission_control/behaviors/set_altitude_heading.h
@@ -44,7 +44,9 @@
 #include <string>
 
 #include "auv_interfaces/StateStamped.h"
+#include "mission_control/behaviors/helpers.h"
 #include "mission_control/behaviors/reactive_action.h"
+
 
 namespace mission_control
 {
@@ -56,13 +58,12 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {  //  NOLINT
-      BT::InputPort<double>("altitude", "Altitude to reach (positive up), in meters"),
-      BT::InputPort<double>("heading", "Heading (or yaw) to reach, in radians"),
-      BT::InputPort<double>("speed_knots", "Cruise speed to command, in knots"),
-      BT::InputPort<double>("altitude_tol", 0.0, "Tolerance for altitude goal, in meters"),
-      BT::InputPort<double>("heading_tol", 0.0, "Tolerance for heading goal, in radians")
-    };
+    return MakePortsList(
+      InputPort<double, HasTolerance>(
+        "altitude", NAN, "Altitude to reach (positive up), in meters"),
+      InputPort<double, HasTolerance, HasAngleUnits>(
+        "heading", NAN, "Heading (or yaw) to reach"),
+      BT::InputPort<double>("speed_knots", NAN, "Cruise speed to command, in knots"));
   }
 
 private:

--- a/mission_control/include/mission_control/behaviors/set_depth_heading.h
+++ b/mission_control/include/mission_control/behaviors/set_depth_heading.h
@@ -44,7 +44,9 @@
 #include <string>
 
 #include "auv_interfaces/StateStamped.h"
+#include "mission_control/behaviors/helpers.h"
 #include "mission_control/behaviors/reactive_action.h"
+
 
 namespace mission_control
 {
@@ -55,11 +57,12 @@ class SetDepthHeadingNode : public ReactiveActionNode
 
   static BT::PortsList providedPorts()
   {
-    return {BT::InputPort<double>("depth", "Depth to reach (positive down), in meters"),  //  NOLINT
-            BT::InputPort<double>("heading", "Heading (or yaw) to reach, in radians"),
-            BT::InputPort<double>("speed_knots", "Cruise speed to command, in knots"),
-            BT::InputPort<double>("depth_tol", 0.0, "Tolerance for depth goal, in meters"),
-            BT::InputPort<double>("heading_tol", 0.0, "Tolerance for heading goal, in radians")};
+    return MakePortsList(
+      InputPort<double, HasTolerance>(
+        "depth", NAN, "Depth to reach (positive down), in meters"),
+      InputPort<double, HasTolerance, HasAngleUnits>(
+        "heading", NAN, "Heading (or yaw) to reach"),
+      BT::InputPort<double>("speed_knots", NAN, "Cruise speed to command, in knots"));
   }
 
  private:

--- a/mission_control/src/behaviors/abort.cpp
+++ b/mission_control/src/behaviors/abort.cpp
@@ -37,6 +37,7 @@
 
 #include "mission_control/AttitudeServo.h"
 
+#include <cmath>
 #include <string>
 
 namespace mission_control
@@ -48,7 +49,7 @@ AbortNode::AbortNode(const std::string& name, const BT::NodeConfiguration& confi
   attitude_servo_pub_ =
     nh_.advertise<mission_control::AttitudeServo>("/mngr/attitude_servo", 1, true);
 
-  nh_.param<double>("/fin_control/max_ctrl_fin_angle", pitch_, 0.3490658503988659);
+  nh_.param<double>("/fin_control/max_ctrl_fin_angle", pitch_, 20 * M_PI / 180.);
 }
 
 BT::NodeStatus AbortNode::setUp()

--- a/mission_control/src/behaviors/fix_rudder.cpp
+++ b/mission_control/src/behaviors/fix_rudder.cpp
@@ -36,6 +36,7 @@
 #include "mission_control/behaviors/fix_rudder.h"
 
 #include "mission_control/FixedRudder.h"
+#include "mission_control/behaviors/helpers.h"
 
 #include <string>
 
@@ -57,21 +58,39 @@ BT::NodeStatus FixRudderNode::tick()
   msg.ena_mask = 0u;
 
   double depth;
-  if (getInput<double>("depth", depth))
+  auto result = getInputValue<double, HasAngleUnits>(this, "depth", depth);
+  if (!result)
+  {
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(depth))
   {
     msg.ena_mask |= mission_control::FixedRudder::DEPTH_ENA;
     msg.depth = depth;
   }
 
   double rudder;
-  if (getInput<double>("rudder", rudder))
+  result = getInputValue<double, HasAngleUnits>(this, "rudder", rudder);
+  if (!result)
+  {
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(rudder))
   {
     msg.ena_mask |= mission_control::FixedRudder::RUDDER_ENA;
     msg.rudder = rudder;
   }
 
   double speed_knots;
-  if (getInput<double>("speed_knots", speed_knots))
+  result = getInput<double>("speed_knots", speed_knots);
+  if (!result)
+  {
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(speed_knots))
   {
     msg.ena_mask |= mission_control::FixedRudder::SPEED_KNOTS_ENA;
     msg.speed_knots = speed_knots;

--- a/mission_control/src/behaviors/fix_rudder.cpp
+++ b/mission_control/src/behaviors/fix_rudder.cpp
@@ -58,7 +58,7 @@ BT::NodeStatus FixRudderNode::tick()
   msg.ena_mask = 0u;
 
   double depth;
-  auto result = getInputValue<double, HasAngleUnits>(this, "depth", depth);
+  auto result = getInput<double>("depth", depth);
   if (!result)
   {
     ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());

--- a/mission_control/src/behaviors/payload_command.cpp
+++ b/mission_control/src/behaviors/payload_command.cpp
@@ -53,9 +53,10 @@ BT::NodeStatus PayloadCommandNode::tick()
 {
   payload_manager::PayloadCommand msg;
   msg.header.stamp = ros::Time::now();
-  if (!getInput<std::string>("command", msg.command))
+  auto result = getInput<std::string>("command", msg.command);
+  if (!result)
   {
-    ROS_ERROR_STREAM("Cannot '" << name() << "', action needs a command");
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
     return BT::NodeStatus::FAILURE;
   }
   payloadCommandPub_.publish(msg);

--- a/mission_control/src/behaviors/set_altitude_heading.cpp
+++ b/mission_control/src/behaviors/set_altitude_heading.cpp
@@ -36,6 +36,7 @@
 #include "mission_control/behaviors/set_altitude_heading.h"
 
 #include "mission_control/AltitudeHeading.h"
+#include "mission_control/behaviors/helpers.h"
 
 #include <string>
 
@@ -55,33 +56,55 @@ BT::NodeStatus SetAltitudeHeadingNode::setUp()
   // Update action parameters
   enable_mask_ = 0u;
 
-  if (getInput<double>("altitude", target_altitude_))
+  auto result =
+    getInputValue<double, HasAngleUnits>(
+      this, "altitude", target_altitude_);
+  if (!result)
   {
-    getInput<double>("altitude_tol", altitude_tolerance_);
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(target_altitude_))
+  {
+    result = getInputTolerance<double, HasAngleUnits>(
+        this, "altitude", altitude_tolerance_);
+    if (!result)
+    {
+      ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+      return BT::NodeStatus::FAILURE;
+    }
     enable_mask_ |= mission_control::AltitudeHeading::ALTITUDE_ENA;
   }
-  else
-  {
-    target_altitude_ = 0.0;
-  }
 
-  if (getInput<double>("heading", target_heading_))
+  result =
+    getInputValue<double, HasAngleUnits>(
+      this, "heading", target_heading_);
+  if (!result)
   {
-    getInput<double>("heading_tol", heading_tolerance_);
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(target_heading_))
+  {
+    result = getInputTolerance<double, HasAngleUnits>(
+      this, "heading", heading_tolerance_);
+    if (!result)
+    {
+      ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+      return BT::NodeStatus::FAILURE;
+    }
     enable_mask_ |= mission_control::AltitudeHeading::HEADING_ENA;
   }
-  else
-  {
-    target_heading_ = 0.0;
-  }
 
-  if (getInput<double>("speed_knots", speed_knots_))
+  result = getInput<double>("speed_knots", speed_knots_);
+  if (!result)
+  {
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(speed_knots_))
   {
     enable_mask_ |= mission_control::AltitudeHeading::SPEED_KNOTS_ENA;
-  }
-  else
-  {
-    speed_knots_ = 0.0;
   }
 
   // Setup state subscriber

--- a/mission_control/src/behaviors/set_altitude_heading.cpp
+++ b/mission_control/src/behaviors/set_altitude_heading.cpp
@@ -56,9 +56,7 @@ BT::NodeStatus SetAltitudeHeadingNode::setUp()
   // Update action parameters
   enable_mask_ = 0u;
 
-  auto result =
-    getInputValue<double, HasAngleUnits>(
-      this, "altitude", target_altitude_);
+  auto result = getInput<double>("altitude", target_altitude_);
   if (!result)
   {
     ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
@@ -66,8 +64,7 @@ BT::NodeStatus SetAltitudeHeadingNode::setUp()
   }
   if (!std::isnan(target_altitude_))
   {
-    result = getInputTolerance<double, HasAngleUnits>(
-        this, "altitude", altitude_tolerance_);
+    result = getInputTolerance<double>(this, "altitude", altitude_tolerance_);
     if (!result)
     {
       ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());

--- a/mission_control/src/behaviors/set_depth_heading.cpp
+++ b/mission_control/src/behaviors/set_depth_heading.cpp
@@ -36,6 +36,7 @@
 #include "mission_control/behaviors/set_depth_heading.h"
 
 #include "mission_control/DepthHeading.h"
+#include "mission_control/behaviors/helpers.h"
 
 #include <string>
 
@@ -55,39 +56,55 @@ BT::NodeStatus SetDepthHeadingNode::setUp()
   // Update action parameters
   enable_mask_ = 0u;
 
-  if (getInput<double>("depth", target_depth_))
+  auto result = getInputValue<double, HasAngleUnits>(this, "depth", target_depth_);
+  if (!result)
   {
-    getInput<double>("depth_tol", depth_tolerance_);
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(target_depth_))
+  {
+    result = getInputTolerance<double, HasAngleUnits>(this, "depth", depth_tolerance_);
+    if (!result)
+    {
+      ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+      return BT::NodeStatus::FAILURE;
+    }
     enable_mask_ |= mission_control::DepthHeading::DEPTH_ENA;
   }
-  else
-  {
-    target_depth_ = 0.0;
-  }
 
-  if (getInput<double>("heading", target_heading_))
+  result = getInputValue<double, HasAngleUnits>(this, "heading", target_heading_);
+  if (!result)
   {
-    getInput<double>("heading_tol", heading_tolerance_);
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(target_heading_))
+  {
+    result = getInputTolerance<double, HasAngleUnits>(this, "heading", heading_tolerance_);
+    if (!result)
+    {
+      ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+      return BT::NodeStatus::FAILURE;
+    }
     enable_mask_ |= mission_control::DepthHeading::HEADING_ENA;
   }
-  else
-  {
-    target_heading_ = 0.0;
-  }
 
-  if (getInput<double>("speed_knots", speed_knots_))
+  result = getInput<double>("speed_knots", speed_knots_);
+  if (!result)
+  {
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+    return BT::NodeStatus::FAILURE;
+  }
+  if (!std::isnan(speed_knots_))
   {
     enable_mask_ |= mission_control::DepthHeading::SPEED_KNOTS_ENA;
-  }
-  else
-  {
-    speed_knots_ = 0.0;
   }
 
   // Setup state subscriber
   state_.reset();
   state_sub_ = nh_.subscribe(
-      "/state", 1, &SetDepthHeadingNode::stateDataCallback, this);
+    "/state", 1, &SetDepthHeadingNode::stateDataCallback, this);
 
   // Publish depth+heading setpoint
   mission_control::DepthHeading msg;

--- a/mission_control/src/behaviors/set_depth_heading.cpp
+++ b/mission_control/src/behaviors/set_depth_heading.cpp
@@ -56,7 +56,7 @@ BT::NodeStatus SetDepthHeadingNode::setUp()
   // Update action parameters
   enable_mask_ = 0u;
 
-  auto result = getInputValue<double, HasAngleUnits>(this, "depth", target_depth_);
+  auto result = getInput<double>("depth", target_depth_);
   if (!result)
   {
     ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
@@ -64,7 +64,7 @@ BT::NodeStatus SetDepthHeadingNode::setUp()
   }
   if (!std::isnan(target_depth_))
   {
-    result = getInputTolerance<double, HasAngleUnits>(this, "depth", depth_tolerance_);
+    result = getInputTolerance<double>(this, "depth", depth_tolerance_);
     if (!result)
     {
       ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());

--- a/mission_control/test/test_attitude_servo_action.py
+++ b/mission_control/test/test_attitude_servo_action.py
@@ -85,6 +85,9 @@ class TestAttitudeServoAction(unittest.TestCase):
         self.mission.read_behavior_parameters('AttitudeServo')
         roll = self.mission.get_behavior_parameter('roll')
         pitch = self.mission.get_behavior_parameter('pitch')
+        pitch_units = self.mission.get_behavior_parameter('pitch-units')
+        self.assertEqual('degrees', pitch_units)
+        pitch = math.radians(float(pitch))
         yaw = self.mission.get_behavior_parameter('yaw')
         speed_knots = self.mission.get_behavior_parameter('speed_knots')
 

--- a/mission_control/test/test_attitude_servo_action.py
+++ b/mission_control/test/test_attitude_servo_action.py
@@ -46,6 +46,13 @@ from mission_interface import MissionInterface
 from mission_interface import wait_for
 
 
+try:
+    from math import isclose
+except ImportError:
+    def isclose(a, b, rel_tol=1e-9):
+        return abs(a - b) < (rel_tol * max(abs(a), abs(b)))
+
+
 class TestAttitudeServoAction(unittest.TestCase):
 
     @classmethod
@@ -83,13 +90,13 @@ class TestAttitudeServoAction(unittest.TestCase):
         self.mission.execute_mission()
 
         self.mission.read_behavior_parameters('AttitudeServo')
-        roll = self.mission.get_behavior_parameter('roll')
-        pitch = self.mission.get_behavior_parameter('pitch')
+        roll = float(self.mission.get_behavior_parameter('roll'))
+        pitch = float(self.mission.get_behavior_parameter('pitch'))
         pitch_units = self.mission.get_behavior_parameter('pitch-units')
         self.assertEqual('degrees', pitch_units)
         pitch = math.radians(float(pitch))
-        yaw = self.mission.get_behavior_parameter('yaw')
-        speed_knots = self.mission.get_behavior_parameter('speed_knots')
+        yaw = float(self.mission.get_behavior_parameter('yaw'))
+        speed_knots = float(self.mission.get_behavior_parameter('speed_knots'))
 
         # Calculate the mask
         enable_mask = 0
@@ -103,10 +110,10 @@ class TestAttitudeServoAction(unittest.TestCase):
             enable_mask |= AttitudeServo.SPEED_KNOTS_ENA
 
         def attitude_servo_goals_are_set():
-            return ((roll is None or self.attitude_servo_goal.roll == float(roll)) and
-                    (pitch is None or self.attitude_servo_goal.pitch == float(pitch)) and
-                    (yaw is None or self.attitude_servo_goal.yaw == float(yaw)) and
-                    (speed_knots is None or self.attitude_servo_goal.speed_knots == float(speed_knots)) and
+            return (isclose(self.attitude_servo_goal.roll, roll) and
+                    isclose(self.attitude_servo_goal.pitch, pitch, rel_tol=1e-6) and
+                    isclose(self.attitude_servo_goal.yaw, yaw) and
+                    isclose(self.attitude_servo_goal.speed_knots, speed_knots) and
                     self.attitude_servo_goal.ena_mask == enable_mask)
 
         self.assertTrue(wait_for(attitude_servo_goals_are_set),
@@ -114,9 +121,9 @@ class TestAttitudeServoAction(unittest.TestCase):
 
         # send data to finish the mission
         msg = StateStamped()
-        msg.state.manoeuvring.pose.mean.orientation.x = 1.0
-        msg.state.manoeuvring.pose.mean.orientation.y = 1.0
-        msg.state.manoeuvring.pose.mean.orientation.z = 1.0
+        msg.state.manoeuvring.pose.mean.orientation.x = roll
+        msg.state.manoeuvring.pose.mean.orientation.y = pitch
+        msg.state.manoeuvring.pose.mean.orientation.z = yaw
         self.simulated_auv_interface_data_pub.publish(msg)
 
         def success_mission_status_is_reported():

--- a/mission_control/test/test_files/test_missions/altitude_heading_mission_test.xml
+++ b/mission_control/test/test_files/test_missions/altitude_heading_mission_test.xml
@@ -4,12 +4,12 @@
   <BehaviorTree ID="MainTree">
     <Sequence name="mission test">
       <Timeout msec="2000">
-        <SetAltitudeHeading 
+        <SetAltitudeHeading
             altitude="1.0"
             heading="2.0"
             speed_knots="3.0"
-            altitude_tol="10.0"
-            heading_tol="10.0"/>
+            altitude-tolerance="10.0"
+            heading-tolerance="10.0"/>
       </Timeout>
     </Sequence>
   </BehaviorTree>

--- a/mission_control/test/test_files/test_missions/attitude_servo_mission_test.xml
+++ b/mission_control/test/test_files/test_missions/attitude_servo_mission_test.xml
@@ -6,12 +6,13 @@
       <Timeout msec="5000">
         <AttitudeServo
             roll="1.0"
-            pitch="1.0"
+            pitch="10.0"
             yaw="1.0"
+            pitch-units="degrees"
             speed_knots="3.0"
-            roll_tol="1.0"
-            pitch_tol="1.0"
-            yaw_tol="1.0"/>
+            roll-tolerance="1.0"
+            pitch-tolerance="1.0"
+            yaw-tolerance="1.0"/>
       </Timeout>
     </Sequence>
   </BehaviorTree>

--- a/mission_control/test/test_files/test_missions/depth_heading_mission_test.xml
+++ b/mission_control/test/test_files/test_missions/depth_heading_mission_test.xml
@@ -6,10 +6,11 @@
       <Timeout msec="2000">
         <SetDepthHeading
             depth="1.0"
-            heading="2.0"
+            heading="5.0"
+            heading-units="degrees"
             speed_knots="3.0"
-            depth_tol="10.0"
-            heading_tol="10.0"/>
+            depth-tolerance="10.0"
+            heading-tolerance="10.0"/>
       </Timeout>
     </Sequence>
   </BehaviorTree>

--- a/mission_control/test/test_files/test_missions/depth_heading_mission_test.xml
+++ b/mission_control/test/test_files/test_missions/depth_heading_mission_test.xml
@@ -9,8 +9,8 @@
             heading="5.0"
             heading-units="degrees"
             speed_knots="3.0"
-            depth-tolerance="10.0"
-            heading-tolerance="10.0"/>
+            depth-tolerance="0.1"
+            heading-tolerance="0.1"/>
       </Timeout>
     </Sequence>
   </BehaviorTree>

--- a/mission_control/test/test_files/test_missions/fixed_rudder_mission_test.xml
+++ b/mission_control/test/test_files/test_missions/fixed_rudder_mission_test.xml
@@ -3,7 +3,7 @@
 <root main_tree_to_execute = "MainTree" >
   <BehaviorTree ID="MainTree">
     <Sequence name="mission test">
-      <FixRudder 
+      <FixRudder
           depth="1.0"
           rudder="2.0"
           speed_knots="3.0"/>

--- a/mission_control/test/test_go_to_waypoint_action.py
+++ b/mission_control/test/test_go_to_waypoint_action.py
@@ -56,7 +56,8 @@ class TestGoToWaypointAction(unittest.TestCase):
         self._waypoint_sub = rospy.Subscriber(
             '/mngr/waypoint', Waypoint,
             self._waypoint_callback)
-        self._state_pub = rospy.Publisher('/state', StateStamped)
+        self._state_pub = rospy.Publisher(
+            '/state', StateStamped, queue_size=1)
         self.mission = MissionInterface()
 
     def _waypoint_callback(self, msg):

--- a/mission_control/test/test_mission_control_behaviors.test
+++ b/mission_control/test/test_mission_control_behaviors.test
@@ -1,5 +1,5 @@
 <launch>
-  <param name="fin_control/max_ctrl_fin_angle" type="double" value="-0.3490658503988659" />
+  <param name="/fin_control/max_ctrl_fin_angle" type="double" value="$(eval radians(20))" />
 
   <include file="$(find mission_control)/launch/mission_control.launch" />
   <!--
@@ -18,27 +18,26 @@
   <test test-name="test_go_to_waypoint_action" pkg="mission_control" type="test_go_to_waypoint_action.py" time-limit="10.0" />
 
   <!--
-      Test if behaviors return Failure state after time out. 
+      Test if behaviors return Failure state after time out.
       The mission control must set fins to surface and Thruster velocity to 0 RPM.
       The argument passed to the test is
             - Mission filename to load and execute.
   -->
-  
-  <test test-name="test_if_mission_control_aborts_when_attitude_servo_behavior_returns_time_out_failure" 
-        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py" 
+
+  <test test-name="test_if_mission_control_aborts_when_attitude_servo_behavior_returns_time_out_failure"
+        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py"
         time-limit="10.0" args="attitude_servo_mission_test.xml"/>
 
-  <test test-name="test_if_mission_control_aborts_when_depth_heading_behavior_returns_time_out_failure" 
-        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py" 
+  <test test-name="test_if_mission_control_aborts_when_depth_heading_behavior_returns_time_out_failure"
+        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py"
         time-limit="10.0" args="depth_heading_mission_test.xml"/>
 
-  <test test-name="test_if_mission_control_aborts_when_altitude_heading_behavior_returns_time_out_failure" 
-        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py" 
+  <test test-name="test_if_mission_control_aborts_when_altitude_heading_behavior_returns_time_out_failure"
+        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py"
         time-limit="10.0" args="altitude_heading_mission_test.xml"/>
 
-  <test test-name="test_if_mission_control_aborts_when_go_to_waypoint_behavior_returns_time_out_failure" 
-        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py" 
+  <test test-name="test_if_mission_control_aborts_when_go_to_waypoint_behavior_returns_time_out_failure"
+        pkg="mission_control" type="test_if_mission_control_aborts_when_behavior_returns_time_out_failure.py"
         time-limit="10.0" args="waypoint_mission_test.xml"/>
 
 </launch>
-

--- a/mission_control/test/test_set_depth_heading_action.py
+++ b/mission_control/test/test_set_depth_heading_action.py
@@ -84,6 +84,9 @@ class TestSetDepthHeadingAction(unittest.TestCase):
         self.mission.read_behavior_parameters('SetDepthHeading')
         depth = self.mission.get_behavior_parameter('depth')
         heading = self.mission.get_behavior_parameter('heading')
+        heading_units = self.mission.get_behavior_parameter('heading-units')
+        self.assertEqual('degrees', heading_units)
+        heading = math.radians(float(heading))
         speed_knots = self.mission.get_behavior_parameter('speed_knots')
 
         # Calculate the mask

--- a/pose_estimator/launch/pose_estimator.launch
+++ b/pose_estimator/launch/pose_estimator.launch
@@ -1,9 +1,9 @@
 <launch>
 	<arg name="maxDepth" default="100.0"/>
-	<arg name="maxRollAng" default="3.14159265358979323846"/>
-	<arg name="maxPitchAng" default="3.14159265358979323846"/>
-	<arg name="maxYawAng" default="6.283185307"/>
-	
+	<arg name="maxRollAng" default="$(eval pi)"/>
+	<arg name="maxPitchAng" default="$(eval pi/2)"/>
+	<arg name="maxYawAng" default="$(eval pi)"/>
+
 	<!-- pose_estimator -->
 	<node pkg="pose_estimator" type="pose_estimator_node" name="pose_estimator_node" output="screen">
 		<param name="rate" type="double" value="100.0"/>


### PR DESCRIPTION
# Description

During manual QA, multiple inconsistencies in how angles were treated were found across the code base. This patch normalizes this situation, using radians everywhere (except within the `autopilot`, as control loops are tuned to work with degrees). To avoid UX degradation,  `$(eval)` substitutions were used to write angle launch arguments in a readable way, and `mission_control` behaviors were extended to support both radians and degrees.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Run all tests in the workspace:

```
catkin_make -j1 run_tests
```

Note: using one job is crucial to avoid concurrent execution of tests that need the hardware.