### PR TITLE
Fix autopilot numerical issues 

### DIFF
--- a/autopilot/include/autopilot/autopilot.h
+++ b/autopilot/include/autopilot/autopilot.h
@@ -146,7 +146,7 @@ private:
   double max_depth_command_;  // m
   double max_altitude_command_;  // m
   double rpms_per_knot_;  // RPMs
-  double max_ctrl_fin_angle_;  // degrees
+  double max_ctrl_fin_angle_in_radians_;
 
   enum class Setpoint
   {

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -173,8 +173,8 @@ AutoPilotNode::AutoPilotNode() : pnh_("~")
   altitude_pid_controller_.initPid(altitude_pgain, altitude_igain, altitude_dgain, altitude_imax, altitude_imin);
   max_altitude_command_ = pnh_.param<double>("max_altitude_command", 25.0);
 
-  max_ctrl_fin_angle_ = radiansToDegrees(
-      nh_.param<double>("/fin_control/max_ctrl_fin_angle", degreesToRadians(10.0)));
+  max_ctrl_fin_angle_in_radians_ =
+      nh_.param<double>("/fin_control/max_ctrl_fin_angle", degreesToRadians(10.0));
 
   active_setpoints_ = Setpoint::Roll | Setpoint::Pitch | Setpoint::Yaw;
   desired_roll_ = pnh_.param<double>("desired_roll", 0.0);
@@ -249,7 +249,7 @@ void AutoPilotNode::missionHeartbeatTimeout(const ros::TimerEvent& ev)
   if (last_heartbeat_stamp_ < ev.last_real)  // no heartbeat received in the past period
   {
     active_setpoints_ = Setpoint::Pitch;
-    desired_pitch_ = -max_ctrl_fin_angle_;
+    desired_pitch_ = -radiansToDegrees(max_ctrl_fin_angle_in_radians_);
     ROS_INFO_THROTTLE(5.0, "Mission control is down");
   }
 }
@@ -265,7 +265,7 @@ void AutoPilotNode::missionStatusCallback(const mission_control::ReportExecuteMi
   if (msg.execute_mission_state == mission_control::ReportExecuteMissionState::COMPLETE)
   {
     active_setpoints_ = Setpoint::Pitch;
-    desired_pitch_ = -max_ctrl_fin_angle_;
+    desired_pitch_ = -radiansToDegrees(max_ctrl_fin_angle_in_radians_);
   }
 }
 
@@ -308,23 +308,24 @@ void AutoPilotNode::mixActuators(double roll, double pitch, double yaw, double t
                              pitch * sin(current_roll_in_radians);
   const double rotated_pitch = yaw * sin(current_roll_in_radians) +
                                pitch * cos(current_roll_in_radians);
-  double d1 = rotated_pitch - rotated_yaw + roll;   // Fin 1 bottom stbd
-  double d2 = rotated_pitch + rotated_yaw + roll;   // Fin 2 top stb
-  double d3 = -rotated_pitch - rotated_yaw + roll;  // Fin 3 bottom port
-  double d4 = -rotated_pitch + rotated_yaw + roll;  // Fin 4 top port
+  double d1 = degreesToRadians(rotated_pitch - rotated_yaw + roll);   // Fin 1 bottom stbd
+  double d2 = degreesToRadians(rotated_pitch + rotated_yaw + roll);   // Fin 2 top stb
+  double d3 = degreesToRadians(-rotated_pitch - rotated_yaw + roll);  // Fin 3 bottom port
+  double d4 = degreesToRadians(-rotated_pitch + rotated_yaw + roll);  // Fin 4 top port
 
-  const double angles[] = {fabs(d1), fabs(d2), fabs(d3), fabs(d4), max_ctrl_fin_angle_};
-  const double max_angle = *std::max_element(std::begin(angles), std::end(angles));
-  d1 = d1 * max_ctrl_fin_angle_ / max_angle;
-  d2 = d2 * max_ctrl_fin_angle_ / max_angle;
-  d3 = d3 * max_ctrl_fin_angle_ / max_angle;
-  d4 = d4 * max_ctrl_fin_angle_ / max_angle;
+  const double angles[] = {
+    fabs(d1), fabs(d2), fabs(d3), fabs(d4), max_ctrl_fin_angle_in_radians_};
+  const double max_angle_in_radians = *std::max_element(std::begin(angles), std::end(angles));
+  d1 = d1 * max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;
+  d2 = d2 * max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;
+  d3 = d3 * max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;
+  d4 = d4 * max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;
 
   fin_control::SetAngles fin_control_message;
-  fin_control_message.f1_angle_in_radians = degreesToRadians(d1);
-  fin_control_message.f2_angle_in_radians = degreesToRadians(d2);
-  fin_control_message.f3_angle_in_radians = degreesToRadians(d3);
-  fin_control_message.f4_angle_in_radians = degreesToRadians(d4);
+  fin_control_message.f1_angle_in_radians = d1;
+  fin_control_message.f2_angle_in_radians = d2;
+  fin_control_message.f3_angle_in_radians = d3;
+  fin_control_message.f4_angle_in_radians = d4;
   fin_control_pub_.publish(fin_control_message);
 
   if (thruster_enabled_)

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -36,6 +36,8 @@
 
 #include "autopilot/autopilot.h"
 
+#include <algorithm>
+
 namespace
 {
 

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -313,8 +313,7 @@ void AutoPilotNode::mixActuators(double roll, double pitch, double yaw, double t
   double d3 = degreesToRadians(-rotated_pitch - rotated_yaw + roll);  // Fin 3 bottom port
   double d4 = degreesToRadians(-rotated_pitch + rotated_yaw + roll);  // Fin 4 top port
 
-  const double angles[] = {
-    fabs(d1), fabs(d2), fabs(d3), fabs(d4), max_ctrl_fin_angle_in_radians_};
+  const double angles[] = {fabs(d1), fabs(d2), fabs(d3), fabs(d4), max_ctrl_fin_angle_in_radians_};
   const double max_angle_in_radians = *std::max_element(std::begin(angles), std::end(angles));
   d1 = d1 * max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;
   d2 = d2 * max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;

--- a/fin_control/msg/ReportAngle.msg
+++ b/fin_control/msg/ReportAngle.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-float32[] angles_in_radians
+float64[] angles_in_radians

--- a/fin_control/msg/SetAngle.msg
+++ b/fin_control/msg/SetAngle.msg
@@ -1,4 +1,4 @@
 uint16  MAX_ANGLE = 40
 uint8   ID
-float32 angle_in_radians
+float64 angle_in_radians
 

--- a/fin_control/msg/SetAngles.msg
+++ b/fin_control/msg/SetAngles.msg
@@ -1,6 +1,6 @@
 uint16  MAX_ANGLE = 40
-float32 f1_angle_in_radians
-float32 f2_angle_in_radians
-float32 f3_angle_in_radians
-float32 f4_angle_in_radians
+float64 f1_angle_in_radians
+float64 f2_angle_in_radians
+float64 f3_angle_in_radians
+float64 f4_angle_in_radians
 


### PR DESCRIPTION
# Description

Rounding errors when commanding fin angles to `max_ctrl_fin_angle` often cause out of range errors in `fin_control`. 

This patch avoids those errors entirely.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Manually run a mission that commands the vehicle to pitch downwards 15 degrees or more. Mission should be successful a no out of range errors should be logged.