### PR TITLE
Bugfixes in Pose Estimator and Vectornav

### DIFF
--- a/jaus_ros_bridge/include/JausDataManager.h
+++ b/jaus_ros_bridge/include/JausDataManager.h
@@ -119,6 +119,7 @@ class JausDataManager {
   ros::Publisher _publisher_ClearFault;
 
   bool _activateManualControlEnabled;
+  bool _deactivateFromOCU;
 
   ros::Timer ActivateManualControl_timer;
 

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -123,16 +123,13 @@ void JausDataManager::ResetAll() {
 void JausDataManager::ActivateManualControlTimeout(const ros::TimerEvent& timer) {
   if (_activateManualControlEnabled) {
     _activateManualControlEnabled = false;
-    // if(debug_mode)
-    ROS_WARN("ActivateManualControl is on!");
+
   } else {
     jaus_ros_bridge::ActivateManualControl msg;
     msg.activate_manual_control = false;
     _publisher_ActivateManualControl.publish(msg);
     _activateManualControlEnabled = false;
     //_needTimerUpdate = false;
-    // if(debug_mode)
-    ROS_WARN("ActivateManualControl is off!");
     // Tell thruster to stop if running
     _thrusterControl.StopThruster();
     //_udp->TimeoutDisconnect();
@@ -163,8 +160,10 @@ void JausDataManager::ProcessReceivedData(char* buffer)
     jaus_ros_bridge::ActivateManualControl msg;
     msg.activate_manual_control = true;
     _publisher_ActivateManualControl.publish(msg);
+    if(!_activateManualControlEnabled)
+      ROS_WARN("ActivateManualControl is on!");
+    
     _activateManualControlEnabled = true;
-
     //_needTimerUpdate = true;
     ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
   }
@@ -172,6 +171,8 @@ void JausDataManager::ProcessReceivedData(char* buffer)
     jaus_ros_bridge::ActivateManualControl msg;
     msg.activate_manual_control = false;
     _publisher_ActivateManualControl.publish(msg);
+    if(_activateManualControlEnabled)
+      ROS_WARN("ActivateManualControl is off!");
     _activateManualControlEnabled = false;
     //_needTimerUpdate = false;
     ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -88,7 +88,7 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
       "/jaus_ros_bridge/enable_logging", 1, true);
 
   _publisher_ClearFault = _nodeHandle.advertise<health_monitor::ClearFault>(
-              "/health_monitor/ClearFault", 1, true);
+              "/health_monitor/clear_fault", 1, true);
 
   _udp = udp;
 

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -88,7 +88,7 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
       "/jaus_ros_bridge/enable_logging", 1, true);
 
   _publisher_ClearFault = _nodeHandle.advertise<health_monitor::ClearFault>(
-              "/health_monitor/clear_fault", 1, true);
+              "/health_monitor/ClearFault", 1, true);
 
   _udp = udp;
 
@@ -102,6 +102,7 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
   ActivateManualControl_timer = _nodeHandle.createTimer(
       ros::Duration(2), &JausDataManager::ActivateManualControlTimeout, this);
   _activateManualControlEnabled = false;
+  _deactivateFromOCU = true;
   //_needTimerUpdate = false;
 }
 
@@ -160,22 +161,25 @@ void JausDataManager::ProcessReceivedData(char* buffer)
     jaus_ros_bridge::ActivateManualControl msg;
     msg.activate_manual_control = true;
     _publisher_ActivateManualControl.publish(msg);
-    if(!_activateManualControlEnabled)
-      ROS_WARN("ActivateManualControl is on!");
+
+    if(!_activateManualControlEnabled&&_deactivateFromOCU){
+      ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
+      _deactivateFromOCU = false;
+    }
     
     _activateManualControlEnabled = true;
     //_needTimerUpdate = true;
-    ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
   }
   else if (strcmp(buffer, DEACTIVATE_MAUNAL_CONTROL) == 0) {
     jaus_ros_bridge::ActivateManualControl msg;
     msg.activate_manual_control = false;
     _publisher_ActivateManualControl.publish(msg);
     if(_activateManualControlEnabled)
-      ROS_WARN("ActivateManualControl is off!");
+      ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);
     _activateManualControlEnabled = false;
+    _deactivateFromOCU = true;
     //_needTimerUpdate = false;
-    ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);
+
     ResetAll();
   }
   else if (strcmp(buffer, ENABLE_LOGGING) == 0) {

--- a/pose_estimator/src/pose_estimator.cpp
+++ b/pose_estimator/src/pose_estimator.cpp
@@ -60,7 +60,7 @@ PoseEstimator::PoseEstimator()
   double min_rate, max_rate;
   pnh_.param("min_rate", min_rate, 1.);  // Hz
   pnh_.param("max_rate", max_rate, 50.);  // Hz
-  
+
   double absolute_steady_band;
   double relative_steady_band;
   pnh_.param("absolute_steady_band", absolute_steady_band, 0.);
@@ -188,7 +188,6 @@ PoseEstimator::PoseEstimator()
       });  // NOLINT(whitespace/braces)
   diagnostics_updater_.add(orientation_yaw_check_);
 
-  ROS_ERROR_STREAM(diagnostics_updater_.getPeriod());
   // Start diagnostics publishing timer
   diagnostics_timer_ = nh_.createTimer(
       ros::Duration(diagnostics_updater_.getPeriod()),

--- a/pose_estimator/src/pose_estimator.cpp
+++ b/pose_estimator/src/pose_estimator.cpp
@@ -60,7 +60,7 @@ PoseEstimator::PoseEstimator()
   double min_rate, max_rate;
   pnh_.param("min_rate", min_rate, 1.);  // Hz
   pnh_.param("max_rate", max_rate, 50.);  // Hz
-
+  
   double absolute_steady_band;
   double relative_steady_band;
   pnh_.param("absolute_steady_band", absolute_steady_band, 0.);
@@ -98,6 +98,7 @@ PoseEstimator::PoseEstimator()
   // Setup diagnostics
   diagnostic_tools::PeriodicMessageStatusParams state_rate_check_params;
   state_rate_check_params.min_acceptable_period(1.0 / max_rate);
+  state_rate_check_params.max_acceptable_period(1.0 / min_rate);
   state_rate_check_params.abnormal_diagnostic(diagnostic_tools::Diagnostic::WARN);
   state_rate_check_params.stale_diagnostic({  // NOLINT(whitespace/braces)
       diagnostic_tools::Diagnostic::STALE,
@@ -187,6 +188,7 @@ PoseEstimator::PoseEstimator()
       });  // NOLINT(whitespace/braces)
   diagnostics_updater_.add(orientation_yaw_check_);
 
+  ROS_ERROR_STREAM(diagnostics_updater_.getPeriod());
   // Start diagnostics publishing timer
   diagnostics_timer_ = nh_.createTimer(
       ros::Duration(diagnostics_updater_.getPeriod()),

--- a/pose_estimator/src/pose_estimator.cpp
+++ b/pose_estimator/src/pose_estimator.cpp
@@ -98,7 +98,6 @@ PoseEstimator::PoseEstimator()
   // Setup diagnostics
   diagnostic_tools::PeriodicMessageStatusParams state_rate_check_params;
   state_rate_check_params.min_acceptable_period(1.0 / max_rate);
-  state_rate_check_params.max_acceptable_period(1.0 / min_rate);
   state_rate_check_params.abnormal_diagnostic(diagnostic_tools::Diagnostic::WARN);
   state_rate_check_params.stale_diagnostic({  // NOLINT(whitespace/braces)
       diagnostic_tools::Diagnostic::STALE,

--- a/vectornav/src/main.cpp
+++ b/vectornav/src/main.cpp
@@ -361,6 +361,14 @@ int run(int argc, char *argv[])
 
     ROS_INFO("Connecting to : %s @ %d Baud", SensorPort.c_str(), SensorBaudrate);
 
+    pubIMU = diagnostic_tools::create_publisher<sensor_msgs::Imu>(
+        n, "vectornav/IMU", 1000);
+    pubMag = n.advertise<sensor_msgs::MagneticField>("vectornav/Mag", 1000);
+    pubGPS = n.advertise<sensor_msgs::NavSatFix>("vectornav/GPS", 1000);
+    pubOdom = n.advertise<nav_msgs::Odometry>("vectornav/Odom", 1000);
+    pubTemp = n.advertise<sensor_msgs::Temperature>("vectornav/Temp", 1000);
+    pubPres = n.advertise<sensor_msgs::FluidPressure>("vectornav/Pres", 1000);
+
     // Create a VnSensor object and connect to sensor
     VnSensor vs;
 
@@ -458,14 +466,6 @@ int run(int argc, char *argv[])
     // Set Data output Freq [Hz]
     vs.writeAsyncDataOutputFrequency(async_output_rate);
     vs.registerAsyncPacketReceivedHandler(&user_data, BinaryAsyncMessageReceived);
-
-    pubIMU = diagnostic_tools::create_publisher<sensor_msgs::Imu>(
-        n, "vectornav/IMU", 1000);
-    pubMag = n.advertise<sensor_msgs::MagneticField>("vectornav/Mag", 1000);
-    pubGPS = n.advertise<sensor_msgs::NavSatFix>("vectornav/GPS", 1000);
-    pubOdom = n.advertise<nav_msgs::Odometry>("vectornav/Odom", 1000);
-    pubTemp = n.advertise<sensor_msgs::Temperature>("vectornav/Temp", 1000);
-    pubPres = n.advertise<sensor_msgs::FluidPressure>("vectornav/Pres", 1000);
 
     resetOdomSrv = n.advertiseService("reset_odom", resetOdom);
 


### PR DESCRIPTION
# Description

This PR fixes issues found testing on vehicle

1) After #137. Not all spurious event were taken into accout. Some assertions could be failing when the vectornav is launched. Now the publishers are created before the communication with the hardware. The configuration of the Diagnostics are mantained after the communication with the hardware has been success. 

2)  Because of the delay between the communication with hardware and the configuration of diagnostics in the pose estimator node the health monitor throws a _POSE_DATA_STALE_ error. The proposed fix in this PR is configure diagnostics in pose estimator updater from parameters.

3) Proposed Fix for #136. It modifies jaus_ros_bridge to log mission control status on change instead every 2 seconds.

4) Health monitor "Clear Fault" topic name is different between health monitor and Jaus Ros bridge. The name was modified in Jaus Ros Bridge Publisher. Now the faults can be cleared from the OCU


## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings

This PR was tested on Hardware.