### PR TITLE
Change frame conventions from NED to SWD

### DIFF
--- a/auv_interfaces/msg/CartesianPose.msg
+++ b/auv_interfaces/msg/CartesianPose.msg
@@ -1,6 +1,6 @@
 # A representation of pose in free space, composed of position
-# and orientation using Euler angles (typically using the x-y-z
-# convention i.e. rpy angles).
+# and orientation using Euler angles (typically using a right
+# handed x-y-z convention i.e. rpy angles).
 
 geometry_msgs/Point position
 geometry_msgs/Vector3 orientation

--- a/auv_interfaces/msg/ManoeuvringState.msg
+++ b/auv_interfaces/msg/ManoeuvringState.msg
@@ -1,7 +1,7 @@
 # A representation of the vehicle's position and attitude with respect to some
 # reference coordinate frame fixed to the Earth (typically) at mean water-free
-# surface and (also typically) following NED conventions i.e. its x-axis
-# pointing towards North, its y-axis pointing towards East, an its z-axis
+# surface and (also typically) following SWD conventions i.e. its x-axis
+# pointing towards South, its y-axis pointing towards West, an its z-axis
 # pointing towards the centre of the Earth.
 #
 # Manoeuvring state is mostly concerned with low-frequency, actuated motion.

--- a/auv_interfaces/msg/SeakeepingState.msg
+++ b/auv_interfaces/msg/SeakeepingState.msg
@@ -1,6 +1,6 @@
 # A representation of the vehicle's short-term position and attitude variations with
 # respect to some reference coordinate frame co-located with the vehicle's body
-# coordinate frame (typicall) following NED conventions but not subject to rapid
+# coordinate frame (typically) following SWD conventions but not subject to rapid
 # orientation changes.
 #
 # Seakeeping state is mostly concerned with high-frequency, external stimuli.

--- a/ixblue_c3_ins/src/ros_helpers.cpp
+++ b/ixblue_c3_ins/src/ros_helpers.cpp
@@ -122,15 +122,17 @@ to_ros_message(const c3_protocol::nav_long::nav_long_data_t& data)
   {
     msg.manoeuvring.pose.mean.position.z = -data.altitude;  // flip z-axis
   }
-  msg.manoeuvring.pose.mean.orientation.x = data.roll;
-  msg.manoeuvring.pose.mean.orientation.y = -data.pitch;  // flip y-axis
+  // Use orientation from INS in NWD frame
+  msg.manoeuvring.pose.mean.orientation.x = -data.roll;  // flip x-axis
+  msg.manoeuvring.pose.mean.orientation.y = data.pitch;
   msg.manoeuvring.pose.mean.orientation.z = wrap_to_pi(data.heading);
   msg.manoeuvring.pose.covariance[21] = std::pow(data.roll_err_sd, 2);
   msg.manoeuvring.pose.covariance[28] = std::pow(data.pitch_err_sd, 2);
   msg.manoeuvring.pose.covariance[35] = std::pow(data.heading_err_sd, 2);
 
-  msg.manoeuvring.velocity.mean.linear.x = data.north_speed;
-  msg.manoeuvring.velocity.mean.linear.y = data.east_speed;
+  // Use speed from INS in NEU frame
+  msg.manoeuvring.velocity.mean.linear.x = -data.north_speed;  // flip x-axis
+  msg.manoeuvring.velocity.mean.linear.y = -data.east_speed;  // flip y-axis
   msg.manoeuvring.velocity.mean.linear.z = -data.vertical_speed;  // flip z-axis
   msg.manoeuvring.velocity.covariance[0] = std::pow(data.north_speed_err_sd, 2);
   msg.manoeuvring.velocity.covariance[7] = std::pow(data.east_speed_err_sd, 2);

--- a/pose_estimator/src/pose_estimator.cpp
+++ b/pose_estimator/src/pose_estimator.cpp
@@ -245,7 +245,7 @@ void PoseEstimator::ahrsCallback(const sensor_msgs::Imu::ConstPtr& ahrs_msg)
     msg.state.geolocation.covariance = last_fix_msg_->position_covariance;
   }
 
-  // Use orientation from AHRS
+  // Use orientation from AHRS in NED frame
   tf::Quaternion orientation(
       ahrs_msg->orientation.x, ahrs_msg->orientation.y,
       ahrs_msg->orientation.z, ahrs_msg->orientation.w);
@@ -253,8 +253,8 @@ void PoseEstimator::ahrsCallback(const sensor_msgs::Imu::ConstPtr& ahrs_msg)
   tf::Matrix3x3 m(orientation);
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
-  msg.state.manoeuvring.pose.mean.orientation.x = roll;
-  msg.state.manoeuvring.pose.mean.orientation.y = pitch;
+  msg.state.manoeuvring.pose.mean.orientation.x = -roll;  // flip x-axis
+  msg.state.manoeuvring.pose.mean.orientation.y = -pitch;  // flip y-axis
   msg.state.manoeuvring.pose.mean.orientation.z = yaw;
   msg.state.manoeuvring.pose.covariance[21] = ahrs_msg->orientation_covariance[0];
   msg.state.manoeuvring.pose.covariance[22] = ahrs_msg->orientation_covariance[1];


### PR DESCRIPTION
# Description

Fixes #141. This patch changes `auv_interfaces/State` frame conventions from NED to South-West-Down (SWD).

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

# How To Test

- Run automated system testbed
- Manually run a test mission