### PR TITLE
Fix missions' current behavior introspection

### DIFF
--- a/mission_control/include/mission_control/behaviors/fix_rudder.h
+++ b/mission_control/include/mission_control/behaviors/fix_rudder.h
@@ -45,12 +45,13 @@
 
 #include "auv_interfaces/StateStamped.h"
 #include "mission_control/behaviors/helpers.h"
+#include "mission_control/behaviors/reactive_action.h"
 
 
 namespace mission_control
 {
 
-class FixRudderNode : public BT::SyncActionNode
+class FixRudderNode : public ReactiveActionNode
 {
 public:
   FixRudderNode(const std::string& name, const BT::NodeConfiguration& config);
@@ -64,7 +65,7 @@ public:
   }
 
 protected:
-  BT::NodeStatus tick() override;
+  BT::NodeStatus doWork() override;
 
 private:
   ros::NodeHandle nodeHandle_;

--- a/mission_control/include/mission_control/behaviors/introspectable_node.h
+++ b/mission_control/include/mission_control/behaviors/introspectable_node.h
@@ -79,6 +79,13 @@ public:
     return current_status;
   }
 
+  void halt() override
+  {
+    introspection::setActivePath(this->config().blackboard.get(), parent_path_);
+
+    BaseNodeT::halt();
+  }
+
  private:
   std::string parent_path_{};
 };
@@ -108,6 +115,13 @@ class IntrospectableNode<BaseNodeT, true> : public BaseNodeT
       introspection::setActivePath(blackboard_.get(), parent_path_);
     }
     return current_status;
+  }
+
+  void halt() override
+  {
+    introspection::setActivePath(blackboard_.get(), parent_path_);
+
+    BaseNodeT::halt();
   }
 
  private:

--- a/mission_control/include/mission_control/behaviors/payload_command.h
+++ b/mission_control/include/mission_control/behaviors/payload_command.h
@@ -44,10 +44,12 @@
 
 #include <string>
 
+#include "mission_control/behaviors/reactive_action.h"
+
 
 namespace mission_control
 {
-class PayloadCommandNode : public BT::SyncActionNode
+class PayloadCommandNode : public ReactiveActionNode
 {
 public:
   PayloadCommandNode(const std::string& name, const BT::NodeConfiguration& config);
@@ -58,7 +60,7 @@ public:
   }
 
 protected:
-  BT::NodeStatus tick() override;
+  BT::NodeStatus doWork() override;
 
 private:
   ros::NodeHandle nodeHandle_;

--- a/mission_control/include/mission_control/mission_control.h
+++ b/mission_control/include/mission_control/mission_control.h
@@ -112,7 +112,7 @@ private:
 
   std::shared_ptr<Mission> current_mission_;
   std::unordered_map<int, std::shared_ptr<Mission>> mission_map_;
-  ReportExecuteMissionState last_mission_state_report_;
+  ReportExecuteMissionState last_mission_state_report_logged_;
 };
 
 }  // namespace mission_control

--- a/mission_control/src/behaviors/fix_rudder.cpp
+++ b/mission_control/src/behaviors/fix_rudder.cpp
@@ -44,13 +44,13 @@ namespace mission_control
 {
 
 FixRudderNode::FixRudderNode(const std::string& name, const BT::NodeConfiguration& config)
-  : BT::SyncActionNode(name, config)
+  : ReactiveActionNode(name, config)
 {
   fixedRudderBehaviorPub_ =
     nodeHandle_.advertise<mission_control::FixedRudder>("/mngr/fixed_rudder", 1, true);
 }
 
-BT::NodeStatus FixRudderNode::tick()
+BT::NodeStatus FixRudderNode::doWork()
 {
   mission_control::FixedRudder msg;
   msg.header.stamp = ros::Time::now();

--- a/mission_control/src/behaviors/payload_command.cpp
+++ b/mission_control/src/behaviors/payload_command.cpp
@@ -43,13 +43,13 @@ namespace mission_control
 {
 
 PayloadCommandNode::PayloadCommandNode(const std::string &name, const BT::NodeConfiguration &config)
-  : BT::SyncActionNode(name, config)
+  : ReactiveActionNode(name, config)
 {
   payloadCommandPub_ =
     nodeHandle_.advertise<payload_manager::PayloadCommand>("/payload_manager/command", 1, true);
 }
 
-BT::NodeStatus PayloadCommandNode::tick()
+BT::NodeStatus PayloadCommandNode::doWork()
 {
   payload_manager::PayloadCommand msg;
   msg.header.stamp = ros::Time::now();

--- a/mission_control/src/mission_control.cpp
+++ b/mission_control/src/mission_control.cpp
@@ -85,7 +85,7 @@ MissionControlNode::MissionControlNode() : nh_(), pnh_("~")
       ros::Duration(1.0 / update_rate),
       &MissionControlNode::update, this);
 
-  last_mission_state_report_.mission_id = 0;
+  last_mission_state_report_logged_.mission_id = 0;
 }
 
 void MissionControlNode::reportHeartbeat(const ros::TimerEvent&)
@@ -107,7 +107,7 @@ const char *to_string(ReportExecuteMissionStateType state)
   switch (state)
   {
     case ReportExecuteMissionState::ERROR:
-      return "ERROR";
+      return "FAILED";
     case ReportExecuteMissionState::ABORTING:
       return "ABORTING";
     case ReportExecuteMissionState::COMPLETE:
@@ -148,14 +148,16 @@ void MissionControlNode::reportOn(const Mission& mission)
       break;
   }
 
-  if (last_mission_state_report_.mission_id != msg.mission_id ||
-      last_mission_state_report_.execute_mission_state != msg.execute_mission_state)
+  if (last_mission_state_report_logged_.mission_id != msg.mission_id ||
+      last_mission_state_report_logged_.execute_mission_state != msg.execute_mission_state)
   {
-    ROS_INFO_STREAM("Mission [" << mission.id() << "] " <<
-                    to_string(msg.execute_mission_state));
-    report_mission_execute_state_pub_.publish(msg);
-    last_mission_state_report_ = msg;
+    ROS_INFO_STREAM(
+      "Mission [" << mission.id() << "] "
+      << to_string(msg.execute_mission_state));
+    last_mission_state_report_logged_ = msg;
   }
+
+  report_mission_execute_state_pub_.publish(msg);
 }
 
 void MissionControlNode::spin()


### PR DESCRIPTION
# Description

This patch fixes `mission_control::IntrospectableNode` to work properly with halting nodes.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [x] Linter tests are passing

