### PR TITLE
Update autopilot.cpp

### DIFF
--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -47,6 +47,10 @@ double degreesToRadians(double degrees) { return ((degrees / 180.0) * M_PI); }
 
 double wrapAngleTo180(double a)
 {
+  while (a < -180.0)
+  {
+    a += 360.0;
+  }
   return fmod((a + 180.0), 360.0) - 180.0;
 }
 


### PR DESCRIPTION
Correct for fmod negative value behavior

# Description

When the delta is less than -180 the vehicle was turning the long way (clockwise). Adding 360 until the value is greater than -180 fixes this issue caused by fmod maintaining the sign of the modulus.

Fixes #148

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [ ] Unit tests are passing
- [ ] Linter tests are passing

# How To Test

Please describe the procedure and/or tests that need to be performed to verify these changes work as expected. Also, include test configuration details if relevant.

## Test A
This is a behavioral test.
1) Set vehicle directed at -135 degrees
2) Command a heading of 135 via a depth heading mission
3) Confirm the vehicle attempts to turn counter-clockwise

## Test B
This is a behavioral test.
1) Set vehicle directed at 135 degrees
2) Command a heading of -135 via a depth heading mission
3) Confirm the vehicle attempts to turn clockwise
