### PR TITLE
Tweak mission_control C++ linter to accept more C++11 constructs.

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -79,6 +79,9 @@ add_executable(${NODE_APP_NAME}
 
 target_link_libraries(${NODE_APP_NAME} ${PROJECT_NAME} ${catkin_LIBRARIES})
 
+set(ROSLINT_CPP_OPTS
+  --filter=-whitespace/braces,-build/c++11,-runtime/references
+)
 roslint_cpp()
 
 #############

--- a/mission_control/include/mission_control/behaviors/go_to_waypoint.h
+++ b/mission_control/include/mission_control/behaviors/go_to_waypoint.h
@@ -58,14 +58,14 @@ public:
 
   static BT::PortsList providedPorts()
   {
-    return {  // NOLINT
+    return {
       BT::InputPort<double>("depth", NAN, "Waypoint depth (positive down), in meters"),
       BT::InputPort<double>("altitude", NAN, "Waypoint altitude (positive up), in meters"),
       BT::InputPort<double>("latitude", NAN, "Waypoint latitude, in degrees"),
       BT::InputPort<double>("longitude", NAN, "Waypoint longitude, in degrees"),
       BT::InputPort<double>("speed_knots", NAN, "Cruise speed to command, in knots"),
       BT::InputPort<double>("tolerance_radius", 0.0, "Radius of the tolerance sphere "
-                            "for UTM coordinates, in meters")};  // NOLINT
+                            "for UTM coordinates, in meters")};
   }
 
 private:

--- a/mission_control/include/mission_control/behaviors/helpers.h
+++ b/mission_control/include/mission_control/behaviors/helpers.h
@@ -67,7 +67,7 @@ UpdatePortsList(
 }
 
 template<typename...Args>
-void expand(Args&&...)  // NOLINT
+void expand(Args&&...)
 {
 }
 

--- a/mission_control/test/test_introspectable_node.cpp
+++ b/mission_control/test/test_introspectable_node.cpp
@@ -98,7 +98,7 @@ TEST(TestIntrospectableActionNode, nominal)
         }
         std::cout << "hi" << std::endl;
         return BT::NodeStatus::RUNNING;
-      }, config);  // NOLINT
+      }, config);
   chat->addChild(say_hi.get());
   tree.nodes.push_back(say_hi);
   auto say_bye =
@@ -112,7 +112,7 @@ TEST(TestIntrospectableActionNode, nominal)
         }
         std::cout << "bye" << std::endl;
         return BT::NodeStatus::RUNNING;
-      }, config);  // NOLINT
+      }, config);
   chat->addChild(say_bye.get());
   tree.nodes.push_back(say_bye);
 

--- a/mission_control/test/test_reactive_action.cpp
+++ b/mission_control/test/test_reactive_action.cpp
@@ -45,7 +45,7 @@ class ReactiveCountDownNode : public ReactiveActionNode
 {
 public:
   explicit ReactiveCountDownNode(size_t start_count)
-    : ReactiveActionNode("countdown", {}), // NOLINT
+    : ReactiveActionNode("countdown", {}),
       start_count_(start_count)
   {
   }


### PR DESCRIPTION
# Description

This patch tweaks roslint options for `mission_control` to mute complaints about valid C++11 features. 

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

```
catkin_make roslint_mission_control
```