### PR TITLE
Add Delay decorator to mission_control

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(${PROJECT_NAME} SHARED
   src/behaviors/set_altitude_heading.cpp
   src/behaviors/payload_command.cpp
   src/behaviors/abort.cpp
+  src/behaviors/delay.cpp
 )
 
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
@@ -110,6 +111,8 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_reactive_action ${PROJECT_NAME} ${catkin_LIBRARIES})
   catkin_add_gtest(test_introspectable_node test/test_introspectable_node.cpp)
   target_link_libraries(test_introspectable_node ${PROJECT_NAME} ${catkin_LIBRARIES})
+  catkin_add_gtest(test_delay_action test/test_delay_action.cpp)
+  target_link_libraries(test_delay_action ${PROJECT_NAME} ${catkin_LIBRARIES})
 
   find_package(rostest REQUIRED)
   add_rostest(test/test_if_mission_control_aborts_when_health_monitor_reports_fault.test)

--- a/mission_control/groot_palette/mission_control_behaviors_palette.xml
+++ b/mission_control/groot_palette/mission_control_behaviors_palette.xml
@@ -1,5 +1,8 @@
 <root>
     <TreeNodesModel>
+        <Decorator ID="Delay">
+            <input_port name="delay_msec">Time to delay child ticking, in milliseconds</input_port>
+        </Decorator>
         <Action ID="AttitudeServo">
             <input_port name="pitch" default="NaN">Pitch angle to reach</input_port>
             <input_port name="pitch-tolerance" default="0.0">Tolerance for pitch</input_port>

--- a/mission_control/include/mission_control/behaviors/delay.h
+++ b/mission_control/include/mission_control/behaviors/delay.h
@@ -1,0 +1,92 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#ifndef MISSION_CONTROL_BEHAVIORS_DELAY_H
+#define MISSION_CONTROL_BEHAVIORS_DELAY_H
+
+#include <behaviortree_cpp_v3/decorator_node.h>
+#include <behaviortree_cpp_v3/decorators/timer_queue.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+
+
+namespace mission_control
+{
+
+class DelayNode : public BT::DecoratorNode
+{
+ public:
+  DelayNode(const std::string& name, std::chrono::milliseconds delay);
+
+  DelayNode(const std::string& name, const BT::NodeConfiguration& config);
+
+  ~DelayNode() override
+  {
+    halt();
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {BT::InputPort<unsigned>("delay_msec", "Time to delay child ticking, in milliseconds")};
+  }
+
+  void halt() override
+  {
+    timer_.cancelAll();
+    DecoratorNode::halt();
+  }
+
+ private:
+  BT::TimerQueue timer_;
+  uint64_t timer_id_;
+
+  BT::NodeStatus tick() override;
+
+  std::chrono::milliseconds delay_;
+
+  enum class Status
+  {
+    PENDING,
+    RUNNING,
+    COMPLETE
+  };
+  std::atomic<Status> delay_status_;
+
+  bool read_parameter_from_ports_;
+};
+
+}   // namespace mission_control
+
+#endif   // MISSION_CONTROL_BEHAVIORS_DELAY_H

--- a/mission_control/src/behaviors/delay.cpp
+++ b/mission_control/src/behaviors/delay.cpp
@@ -1,0 +1,107 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "mission_control/behaviors/delay.h"
+
+#include <ros/ros.h>
+
+#include <string>
+
+
+namespace mission_control
+{
+
+DelayNode::DelayNode(const std::string& name,  std::chrono::milliseconds delay)
+  : DecoratorNode(name, {}),
+    delay_(delay),
+    delay_status_(Status::PENDING),
+    read_parameter_from_ports_(false)
+{
+    setRegistrationID("Delay");
+}
+
+DelayNode::DelayNode(const std::string& name, const BT::NodeConfiguration& config)
+  : DecoratorNode(name, config),
+    delay_(0u),
+    delay_status_(Status::PENDING),
+    read_parameter_from_ports_(true)
+{
+}
+
+BT::NodeStatus DelayNode::tick()
+{
+  if (Status::PENDING == delay_status_)
+  {
+    if (read_parameter_from_ports_)
+    {
+      unsigned msec_;
+      auto result = getInput("delay_msec", msec_);
+      if (!result)
+      {
+        ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+        return BT::NodeStatus::FAILURE;
+      }
+      delay_ = std::chrono::milliseconds(msec_);
+    }
+    delay_status_ = Status::RUNNING;
+
+    timer_id_ = timer_.add(
+      delay_,
+      [this](bool aborted)
+      {
+        if (!aborted)
+        {
+          delay_status_ = Status::COMPLETE;
+        }
+        else
+        {
+          delay_status_ = Status::PENDING;
+        }
+      });
+  }
+
+  if (Status::COMPLETE != delay_status_)
+  {
+    return BT::NodeStatus::RUNNING;
+  }
+
+  BT::NodeStatus child_status = child()->executeTick();
+  if (BT::NodeStatus::RUNNING != child_status)
+  {
+    delay_status_ = Status::PENDING;
+  }
+  return child_status;
+}
+
+}   // namespace mission_control

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -40,6 +40,7 @@
 
 #include "mission_control/behaviors/abort.h"
 #include "mission_control/behaviors/attitude_servo.h"
+#include "mission_control/behaviors/delay.h"
 #include "mission_control/behaviors/fix_rudder.h"
 #include "mission_control/behaviors/go_to_waypoint.h"
 #include "mission_control/behaviors/payload_command.h"
@@ -71,6 +72,7 @@ class MissionBehaviorTreeFactory : public BT::BehaviorTreeFactory
     // TODO(hidmic): load behavior classes from ROS plugins
     this->registerNodeType<IntrospectableNode<AbortNode>>("Abort");
     this->registerNodeType<IntrospectableNode<AttitudeServoNode>>("AttitudeServo");
+    this->registerNodeType<IntrospectableNode<DelayNode>>("Delay");
     this->registerNodeType<IntrospectableNode<FixRudderNode>>("FixRudder");
     this->registerNodeType<IntrospectableNode<GoToWaypointNode>>("GoToWaypoint");
     this->registerNodeType<IntrospectableNode<PayloadCommandNode>>("PayloadCommand");

--- a/mission_control/test/test_delay_action.cpp
+++ b/mission_control/test/test_delay_action.cpp
@@ -1,0 +1,81 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <behaviortree_cpp_v3/actions/always_success_node.h>
+
+#include <chrono>
+#include <thread>
+
+#include "mission_control/behaviors/delay.h"
+
+
+namespace mission_control
+{
+namespace
+{
+
+TEST(TestDelayNode, nominal)
+{
+  DelayNode root(
+    "delay some time", std::chrono::milliseconds(500));
+  BT::AlwaysSuccessNode child("just succeed");
+  root.setChild(&child);
+
+  BT::NodeStatus status = root.executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  do {
+    std::this_thread::sleep_for(
+      std::chrono::milliseconds(100));
+    status = root.executeTick();
+  } while (BT::NodeStatus::RUNNING == status);
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);
+
+  status = root.executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  std::this_thread::sleep_for(
+    std::chrono::milliseconds(100));
+  root.halt();
+  EXPECT_EQ(root.status(), BT::NodeStatus::IDLE);
+}
+
+}  // namespace
+}  // namespace mission_control
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Description

This patch adds a `Delay` decorator to `mission_control`. This is a variation of the `Delay` decorator as found upstream (available in Melodic and onwards) that better handles non-synchronous actions.

Depends on #153.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

```
catkin_make run_tests_mission_control
```