### PR TITLE
Add LogToBagfile decorator to mission_control

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -12,10 +12,12 @@ find_package(catkin REQUIRED COMPONENTS
   health_monitor
   message_generation
   payload_manager
+  rosbag_storage
   roscpp
   roslint
   rospy
   std_msgs
+  topic_tools
 )
 
 add_message_files(
@@ -68,6 +70,9 @@ add_library(${PROJECT_NAME} SHARED
   src/behaviors/payload_command.cpp
   src/behaviors/abort.cpp
   src/behaviors/delay.cpp
+  src/behaviors/log_to_bagfile.cpp
+  src/behaviors/internal/async_bag_writer.cpp
+  src/behaviors/internal/generic_subscription.cpp
 )
 
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/mission_control/groot_palette/mission_control_behaviors_palette.xml
+++ b/mission_control/groot_palette/mission_control_behaviors_palette.xml
@@ -1,5 +1,18 @@
 <root>
     <TreeNodesModel>
+        <Decorator ID="LogToBagfile">
+            <input_port name="prefix" default="mission_bag_">
+                Prefix for bag filename. If relative, it is resolved against the ROS log directory.
+                If it lacks the '.bag' extension, a '{timestamp}.bag' suffix is appended.
+            </input_port>
+            <input_port name="topics" default="all">
+                Topic names to be logged as a comma-separated list. If the 'all' value is given, all
+                topics are logged by periodically looking up the ROS graph.
+            </input_port>
+            <input_port name="compression" default="none">
+                Compression type to be used. Supported types are 'none', 'bz2', and 'lz4'.
+            </input_port>
+        </Decorator>
         <Decorator ID="Delay">
             <input_port name="delay_msec">Time to delay child ticking, in milliseconds</input_port>
         </Decorator>

--- a/mission_control/include/mission_control/behaviors/internal/async_bag_writer.h
+++ b/mission_control/include/mission_control/behaviors/internal/async_bag_writer.h
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#ifndef MISSION_CONTROL_BEHAVIORS_INTERNAL_ASYNC_BAG_WRITER_H
+#define MISSION_CONTROL_BEHAVIORS_INTERNAL_ASYNC_BAG_WRITER_H
+
+#include <ros/ros.h>
+#include <rosbag/bag.h>
+#include <topic_tools/shape_shifter.h>
+
+#include <cstdint>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace mission_control
+{
+namespace internal
+{
+
+class AsyncBagWriter final
+{
+ public:
+  struct Options
+  {
+    rosbag::CompressionType compression{
+      rosbag::compression::Uncompressed};
+    uint32_t buffer_size{256};  // MB
+    uint32_t chunk_size{128};  // KB
+  };
+
+  void start(const std::string& path, const Options& options);
+
+  bool write(
+    const std::string& topic,
+    const ros::MessageEvent<const topic_tools::ShapeShifter>& event);
+
+  void stop();
+
+ private:
+  void doWrite();
+
+  rosbag::Bag bag_{};
+  std::string path_{};
+
+  struct Entry
+  {
+    std::string topic;
+    ros::MessageEvent<const topic_tools::ShapeShifter> event;
+  };
+  std::deque<Entry> buffer_{};
+  uint64_t buffer_size_{0u};
+  uint64_t max_buffer_size_{0u};
+
+  std::exception_ptr exception_{nullptr};
+
+  bool stop_requested_{false};
+  std::condition_variable event_{};
+  std::thread worker_thread_{};
+  std::mutex mutex_{};
+};
+
+}  // namespace internal
+}  // namespace mission_control
+
+#endif  // MISSION_CONTROL_BEHAVIORS_INTERNAL_ASYNC_BAG_WRITER_H

--- a/mission_control/include/mission_control/behaviors/internal/generic_subscription.h
+++ b/mission_control/include/mission_control/behaviors/internal/generic_subscription.h
@@ -1,0 +1,92 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#ifndef MISSION_CONTROL_BEHAVIORS_INTERNAL_GENERIC_SUBSCRIPTION_H
+#define MISSION_CONTROL_BEHAVIORS_INTERNAL_GENERIC_SUBSCRIPTION_H
+
+#include <ros/ros.h>
+#include <topic_tools/shape_shifter.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace mission_control
+{
+namespace internal
+{
+
+class GenericSubscriptionImpl;
+
+class GenericSubscription final
+{
+ public:
+  // Uses boost because ROS does
+  using CallbackT = boost::function<void(
+    const std::string&,
+    const ros::MessageEvent<
+      const topic_tools::ShapeShifter
+    > &)>;
+
+  GenericSubscription();
+  ~GenericSubscription();
+
+  GenericSubscription(GenericSubscription&&);
+
+  GenericSubscription&
+  operator=(GenericSubscription&&);
+
+  static
+  GenericSubscription
+  create(const ros::NodeHandle& nh,
+         const CallbackT& callback);
+
+  static
+  GenericSubscription create(
+    const ros::NodeHandle& nh,
+    const std::vector<std::string>& topics,
+    const CallbackT& callback);
+
+  void shutdown();
+
+ private:
+  explicit GenericSubscription(
+    std::unique_ptr<GenericSubscriptionImpl> impl);
+
+  std::unique_ptr<GenericSubscriptionImpl> impl_;
+};
+
+}  // namespace internal
+}  // namespace mission_control
+
+#endif  // MISSION_CONTROL_BEHAVIORS_INTERNAL_GENERIC_SUBSCRIPTION_H

--- a/mission_control/include/mission_control/behaviors/log_to_bagfile.h
+++ b/mission_control/include/mission_control/behaviors/log_to_bagfile.h
@@ -1,0 +1,101 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#ifndef MISSION_CONTROL_BEHAVIORS_LOG_TO_BAGFILE_H
+#define MISSION_CONTROL_BEHAVIORS_LOG_TO_BAGFILE_H
+
+#include <behaviortree_cpp_v3/basic_types.h>
+#include <behaviortree_cpp_v3/decorator_node.h>
+
+#include <ros/ros.h>
+
+#include <string>
+#include <vector>
+
+#include "mission_control/behaviors/internal/async_bag_writer.h"
+#include "mission_control/behaviors/internal/generic_subscription.h"
+
+
+namespace mission_control
+{
+
+class LogToBagfileNode : public BT::DecoratorNode
+{
+ public:
+  struct Options
+  {
+    static BT::PortsList portsList()
+    {
+      static const Options options;
+      return {
+        BT::InputPort<std::string>(
+          "prefix", options.prefix, "Prefix for bag filename"),
+        BT::InputPort<std::string>(
+          "topics", "all", "Topics to log, 'all' by default"),
+        BT::InputPort<rosbag::CompressionType>(
+          "compression", options.writer_options.compression,
+          "Compression type for bag")};
+    }
+
+    static Options populateFromPorts(BT::TreeNode * node);
+
+    std::string prefix{"mission_bag_"};
+    std::vector<std::string> topics{};
+    internal::AsyncBagWriter::Options writer_options{};
+  };
+
+  static BT::PortsList providedPorts() { return Options::portsList(); }
+
+  LogToBagfileNode(const std::string& name, Options options);
+
+  LogToBagfileNode(const std::string& name, const BT::NodeConfiguration& config);
+
+  void halt() override;
+
+ private:
+  BT::NodeStatus tick() override;
+
+  bool startLogging();
+  bool stopLogging();
+
+  ros::NodeHandle nh_;
+  Options options_;
+  bool read_parameter_from_ports_;
+
+  internal::AsyncBagWriter bag_writer_;
+  internal::GenericSubscription subscription_;
+};
+
+}  // namespace mission_control
+
+#endif  // MISSION_CONTROL_BEHAVIORS_LOG_TO_BAGFILE_H

--- a/mission_control/include/mission_control/behaviors/log_to_bagfile.h
+++ b/mission_control/include/mission_control/behaviors/log_to_bagfile.h
@@ -59,12 +59,16 @@ class LogToBagfileNode : public BT::DecoratorNode
       static const Options options;
       return {
         BT::InputPort<std::string>(
-          "prefix", options.prefix, "Prefix for bag filename"),
+          "prefix", options.prefix,
+          "Prefix for bag filename. If relative, it is resolved against the ROS log directory. "
+          "If it lacks the '.bag' extension, a '{timestamp}.bag' suffix is appended."),
         BT::InputPort<std::string>(
-          "topics", "all", "Topics to log, 'all' by default"),
+          "topics", "all",
+          "Topic names to be logged as a comma-separated list. If the 'all' value is given, "
+          "all topics are logged by periodically looking up the ROS graph."),
         BT::InputPort<rosbag::CompressionType>(
           "compression", options.writer_options.compression,
-          "Compression type for bag")};
+          "Compression type to be used. Supported types are 'none', 'bz2', and 'lz4'.")};
     }
 
     static Options populateFromPorts(BT::TreeNode * node);

--- a/mission_control/package.xml
+++ b/mission_control/package.xml
@@ -16,10 +16,12 @@
   <build_depend>health_monitor</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>payload_manager</build_depend>
+  <build_depend>rosbag_storage</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>topic_tools</build_depend>
   <build_export_depend>auv_interfaces</build_export_depend>
   <build_export_depend>health_monitor</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
@@ -33,9 +35,11 @@
   <exec_depend>health_monitor</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>payload_manager</exec_depend>
+  <exec_depend>rosbag_storage</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>

--- a/mission_control/package.xml
+++ b/mission_control/package.xml
@@ -40,6 +40,8 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <test_depend>rosbag</test_depend>
+  <test_depend>rospkg</test_depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>

--- a/mission_control/src/behaviors/internal/async_bag_writer.cpp
+++ b/mission_control/src/behaviors/internal/async_bag_writer.cpp
@@ -1,0 +1,145 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#include "mission_control/behaviors/internal/async_bag_writer.h"
+
+#include <string>
+
+namespace mission_control
+{
+namespace internal
+{
+
+void AsyncBagWriter::start(const std::string& path, const Options& options)
+{
+  // Open temporary bag for writing
+  path_ = path;
+  std::string tmp_path = path_ + ".active";
+  bag_.open(tmp_path, rosbag::bagmode::Write);
+  bag_.setChunkThreshold(1024 * options.chunk_size);
+  bag_.setCompression(options.compression);
+  max_buffer_size_ = 1024 * 1024 * options.buffer_size;
+
+  // Start asynchronous writing
+  exception_ = nullptr;
+  stop_requested_ = false;
+  worker_thread_ = std::thread(
+    boost::bind(&AsyncBagWriter::doWrite, this));
+}
+
+void AsyncBagWriter::stop()
+{
+  // Stop asynchronous writing
+  stop_requested_ = true;
+  event_.notify_one();
+  worker_thread_.join();
+  buffer_.clear();
+  buffer_size_ = 0u;
+
+  // Move temporary bag to its final location
+  std::string tmp_path = bag_.getFileName();
+  bag_.close();  // Close bagfile before moving
+  if (std::rename(tmp_path.c_str(), path_.c_str()))
+  {
+    throw std::system_error(
+      std::error_code(errno, std::generic_category()),
+      strerror(errno));
+  }
+  path_.clear();
+
+  // Propagate errors, if any
+  if (exception_)
+  {
+    std::rethrow_exception(exception_);
+  }
+}
+
+bool AsyncBagWriter::write(
+  const std::string& topic,
+  const ros::MessageEvent<const topic_tools::ShapeShifter>& event)
+{
+  if (exception_)
+  {
+    // Skip write
+    return false;
+  }
+
+  // Write to buffer and notify asynchronous writer
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffer_.push_back(Entry{topic, event});
+    buffer_size_ += event.getMessage()->size();
+    if (max_buffer_size_ > 0)
+    {
+      while (buffer_size_ > max_buffer_size_)
+      {
+        Entry& entry = buffer_.front();
+        buffer_size_ -= entry.event.getMessage()->size();
+        buffer_.pop_front();
+      }
+    }
+  }
+  event_.notify_one();
+
+  return true;
+}
+
+void
+AsyncBagWriter::doWrite()
+{
+  try
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (true)
+    {
+      while (!buffer_.empty())
+      {
+        const Entry& entry = buffer_.front();
+        bag_.write(entry.topic, entry.event);
+        buffer_.pop_front();
+      }
+      if (stop_requested_)
+      {
+        break;
+      }
+      event_.wait(lock);
+    }
+  }
+  catch(...)
+  {
+    exception_ = std::current_exception();
+  }
+}
+
+}  // namespace internal
+}  // namespace mission_control

--- a/mission_control/src/behaviors/internal/generic_subscription.cpp
+++ b/mission_control/src/behaviors/internal/generic_subscription.cpp
@@ -1,0 +1,190 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "mission_control/behaviors/internal/generic_subscription.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+
+namespace mission_control
+{
+namespace internal
+{
+
+class GenericSubscriptionImpl
+{
+ public:
+  explicit GenericSubscriptionImpl(const ros::NodeHandle& nh)
+    : nh_(nh)
+  {
+  }
+
+  virtual ~GenericSubscriptionImpl() = default;
+
+  virtual void shutdown()
+  {
+    for (auto& kv : active_subscribers_)
+    {
+      kv.second.shutdown();
+    }
+    active_subscribers_.clear();
+  }
+
+ protected:
+  bool isSubscribed(const std::string& topic) const
+  {
+    return active_subscribers_.count(topic) > 0;
+  }
+
+  void subscribe(
+    const std::string& topic,
+    const GenericSubscription::CallbackT& callback)
+  {
+    ros::SubscribeOptions ops;
+    ops.topic = topic;
+    ops.queue_size = 100;
+    ops.md5sum = ros::message_traits::md5sum<topic_tools::ShapeShifter>();
+    ops.datatype = ros::message_traits::datatype<topic_tools::ShapeShifter>();
+    ops.helper = boost::make_shared<ros::SubscriptionCallbackHelperT<
+      const ros::MessageEvent<const topic_tools::ShapeShifter> &> >(
+        boost::bind(callback, topic, _1));
+    active_subscribers_[topic] = nh_.subscribe(ops);
+  }
+
+ private:
+  ros::NodeHandle nh_;
+  std::unordered_map<std::string, ros::Subscriber> active_subscribers_;
+};
+
+class NonTrackingImpl : public GenericSubscriptionImpl
+{
+ public:
+  NonTrackingImpl(
+    const ros::NodeHandle& nh,
+    const std::vector<std::string>& topics,
+    const GenericSubscription::CallbackT& callback)
+  : GenericSubscriptionImpl(nh)
+  {
+    for (const auto& topic : topics)
+    {
+      subscribe(topic, callback);
+    }
+  }
+};
+
+class TrackingImpl : public GenericSubscriptionImpl
+{
+ public:
+  TrackingImpl(
+    const ros::NodeHandle& nh,
+    const GenericSubscription::CallbackT& callback)
+  : GenericSubscriptionImpl(nh), callback_(callback)
+  {
+    timer_ = nh.createTimer(
+      ros::Duration(1.0),
+      boost::bind(&TrackingImpl::trackTopics, this));
+  }
+
+  void shutdown() override
+  {
+    timer_.stop();
+    GenericSubscriptionImpl::shutdown();
+  }
+
+ private:
+  void trackTopics()
+  {
+    ros::master::V_TopicInfo topics;
+    if (ros::master::getTopics(topics))
+    {
+      for (const ros::master::TopicInfo& topic : topics)
+      {
+        if (!isSubscribed(topic.name))
+        {
+          subscribe(topic.name, callback_);
+        }
+      }
+    }
+  }
+
+  ros::Timer timer_;
+  GenericSubscription::CallbackT callback_;
+};
+
+GenericSubscription
+GenericSubscription::create(
+  const ros::NodeHandle& nh,
+  const CallbackT& callback)
+{
+  std::unique_ptr<GenericSubscriptionImpl> impl{
+    new TrackingImpl(nh, callback)};
+  return GenericSubscription{std::move(impl)};
+}
+
+GenericSubscription
+GenericSubscription::create(
+  const ros::NodeHandle& nh,
+  const std::vector<std::string>& topics,
+  const CallbackT& callback)
+{
+  std::unique_ptr<GenericSubscriptionImpl> impl{
+    new NonTrackingImpl(nh, topics, callback)};
+  return GenericSubscription{std::move(impl)};
+}
+
+GenericSubscription::GenericSubscription(
+  std::unique_ptr<GenericSubscriptionImpl> impl)
+  : impl_(std::move(impl))
+{
+}
+
+GenericSubscription::GenericSubscription() = default;
+
+GenericSubscription::GenericSubscription(GenericSubscription&&) = default;
+
+GenericSubscription&
+GenericSubscription::operator=(GenericSubscription&&) = default;
+
+GenericSubscription::~GenericSubscription() = default;
+
+void
+GenericSubscription::shutdown()
+{
+  impl_->shutdown();
+}
+
+}  // namespace internal
+}  // namespace mission_control

--- a/mission_control/src/behaviors/log_to_bagfile.cpp
+++ b/mission_control/src/behaviors/log_to_bagfile.cpp
@@ -1,0 +1,268 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <boost/date_time/local_time/local_time.hpp>
+#include <ros/file_log.h>
+
+#include <cassert>
+#include <sstream>
+#include <string>
+
+#include "mission_control/behaviors/log_to_bagfile.h"
+
+
+namespace BT
+{
+
+template<>
+std::string
+toStr<rosbag::CompressionType>(rosbag::CompressionType compression)
+{
+  switch (compression)
+  {
+    case rosbag::compression::Uncompressed:
+      return "none";
+    case rosbag::compression::BZ2:
+      return "bz2";
+    case rosbag::compression::LZ4:
+      return "lz4";
+    default:
+      throw RuntimeError(
+        "unknown compression type: " + std::to_string(compression));
+  }
+}
+
+template<>
+rosbag::CompressionType
+convertFromString<rosbag::CompressionType>(StringView str)
+{
+  if ("none" == str)
+  {
+    return rosbag::compression::Uncompressed;
+  }
+  if ("bz2" == str)
+  {
+    return rosbag::compression::BZ2;
+  }
+  if ("lz4" == str)
+  {
+    return rosbag::compression::LZ4;
+  }
+  throw RuntimeError(
+    "unknown compression type: " + str.to_string());
+}
+}  // namespace BT
+
+namespace mission_control
+{
+
+LogToBagfileNode::Options
+LogToBagfileNode::Options::populateFromPorts(BT::TreeNode * node)
+{
+  assert(node != nullptr);
+
+  Options options;
+
+  auto result = node->getInput<std::string>("prefix", options.prefix);
+  if (!result)
+  {
+    ROS_WARN_STREAM(
+      "Cannot fetch bag prefix for '" << node->name() << "': " << result.error());
+    ROS_WARN_STREAM("Falling back to default bag prefix");
+  }
+
+  std::string topics;
+  result = node->getInput<std::string>("topics", topics);
+  if (result)
+  {
+    if (topics != "all")
+    {
+      for (const auto& topic : BT::splitString(topics, ';'))
+      {
+        options.topics.push_back(topic.to_string());
+      }
+    }
+  }
+  else
+  {
+    ROS_WARN_STREAM(
+      "Cannot fetch topics to log for '" << node->name() << "': " << result.error());
+    ROS_WARN_STREAM("Falling back to default topics to log");
+  }
+
+  result = node->getInput<rosbag::CompressionType>(
+    "compression", options.writer_options.compression);
+  if (!result)
+  {
+    ROS_WARN_STREAM(
+      "Cannot fetch bag compression for '" << node->name() << "': " << result.error());
+    ROS_WARN_STREAM("Falling back to default bag compression");
+  }
+
+  return options;
+}
+
+LogToBagfileNode::LogToBagfileNode(const std::string& name, Options options)
+  : BT::DecoratorNode(name, {}),
+    options_(options),
+    read_parameter_from_ports_(false)
+{
+    setRegistrationID("LogToBagfile");
+}
+
+LogToBagfileNode::LogToBagfileNode(const std::string& name, const BT::NodeConfiguration& config)
+  : BT::DecoratorNode(name, config),
+    read_parameter_from_ports_(true)
+{
+}
+
+namespace
+{
+
+std::string
+generateBagfilePath(const std::string& prefix)
+{
+  std::stringstream path;
+  auto prefix_view = nonstd::to_string_view(prefix);
+  if (!prefix_view.starts_with("/"))
+  {
+    path << ros::file_log::getLogDirectory() << "/";
+  }
+  path << prefix;
+  if (!prefix_view.ends_with(".bag"))
+  {
+    const boost::posix_time::ptime now =
+      boost::posix_time::second_clock::local_time();
+    boost::posix_time::time_facet facet("%Y-%m-%d-%H-%M-%S");
+    path.imbue(std::locale(path.getloc(), &facet));
+    path << now << ".bag";
+  }
+  return path.str();
+}
+
+}  // namespace
+
+bool
+LogToBagfileNode::startLogging()
+{
+  try
+  {
+    bag_writer_.start(
+      generateBagfilePath(options_.prefix),
+      options_.writer_options);
+    using MessageEventT =
+      ros::MessageEvent<const topic_tools::ShapeShifter>;
+    auto callback =
+      [this](const std::string& topic, const MessageEventT& event)
+      {
+        if (!bag_writer_.write(topic, event))
+        {
+          ROS_WARN_STREAM("'" << name() << "' stopped logging due to errors");
+          subscription_.shutdown();
+        }
+      };
+    subscription_ =
+      !options_.topics.empty()?
+      internal::GenericSubscription::create(nh_, options_.topics, callback) :
+      internal::GenericSubscription::create(nh_, callback);
+    return true;
+  }
+  catch (const rosbag::BagIOException & e)
+  {
+    ROS_ERROR_STREAM("Cannot '" << name() << "': " << e.what());
+    return false;
+  }
+}
+
+bool
+LogToBagfileNode::stopLogging()
+{
+  try
+  {
+    subscription_.shutdown();
+    bag_writer_.stop();
+    return true;
+  }
+  catch(const rosbag::BagIOException & e)
+  {
+    ROS_ERROR_STREAM("Failed to '" << name() << "': " << e.what());
+    return false;
+  }
+}
+
+void
+LogToBagfileNode::halt()
+{
+  if (BT::NodeStatus::RUNNING == status())
+  {
+    (void)stopLogging();
+  }
+  DecoratorNode::halt();
+}
+
+BT::NodeStatus
+LogToBagfileNode::tick()
+{
+  if (BT::NodeStatus::IDLE == status())
+  {
+    if (read_parameter_from_ports_)
+    {
+      options_ = Options::populateFromPorts(this);
+    }
+
+    if (!startLogging())
+    {
+      return BT::NodeStatus::FAILURE;
+    }
+
+    setStatus(BT::NodeStatus::RUNNING);
+  }
+
+  if (BT::NodeStatus::RUNNING == status())
+  {
+    BT::NodeStatus status = child()->executeTick();
+    if (BT::NodeStatus::RUNNING != status)
+    {
+      if (!stopLogging())
+      {
+        status = BT::NodeStatus::FAILURE;
+      }
+      setStatus(status);
+    }
+  }
+
+  return status();
+}
+
+}   // namespace mission_control

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -43,6 +43,7 @@
 #include "mission_control/behaviors/delay.h"
 #include "mission_control/behaviors/fix_rudder.h"
 #include "mission_control/behaviors/go_to_waypoint.h"
+#include "mission_control/behaviors/log_to_bagfile.h"
 #include "mission_control/behaviors/payload_command.h"
 #include "mission_control/behaviors/set_altitude_heading.h"
 #include "mission_control/behaviors/set_depth_heading.h"
@@ -75,6 +76,7 @@ class MissionBehaviorTreeFactory : public BT::BehaviorTreeFactory
     this->registerNodeType<IntrospectableNode<DelayNode>>("Delay");
     this->registerNodeType<IntrospectableNode<FixRudderNode>>("FixRudder");
     this->registerNodeType<IntrospectableNode<GoToWaypointNode>>("GoToWaypoint");
+    this->registerNodeType<IntrospectableNode<LogToBagfileNode>>("LogToBagfile");
     this->registerNodeType<IntrospectableNode<PayloadCommandNode>>("PayloadCommand");
     this->registerNodeType<IntrospectableNode<SetAltitudeHeadingNode>>("SetAltitudeHeading");
     this->registerNodeType<IntrospectableNode<SetDepthHeadingNode>>("SetDepthHeading");

--- a/mission_control/test/mission_interface.py
+++ b/mission_control/test/mission_interface.py
@@ -97,7 +97,7 @@ class MissionInterface:
         self.execute_mission_state.append(msg.execute_mission_state)
 
     def callback_mission_load_state(self, msg):
-        self.mission_load_state = msg.load_state
+        self.mission_load_state = msg
 
     def load_mission(self, mission_name):
         # Simulate Jaus Ros Bridge sending a Load Command and wait for

--- a/mission_control/test/test_log_to_bagfile_action.py
+++ b/mission_control/test/test_log_to_bagfile_action.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+"""
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+"""
+import os
+import tempfile
+import textwrap
+import unittest
+
+import rosbag
+import rospy
+import rostest
+
+from mission_control.msg import ReportExecuteMissionState
+from mission_control.msg import ReportLoadMissionState
+from mission_interface import MissionInterface
+from mission_interface import wait_for
+
+
+class TestLogToBagfileAction(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rospy.init_node('node_to_test_log_to_bagfile')
+
+    def setUp(self):
+        self.mission_interface = MissionInterface()
+
+    def _log_one_topic_to_bagfile(self, compression_type):
+        bag_name = 'one_topic.{}.bag'.format(compression_type)
+        topic_name = '/mngr/fixed_rudder'
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(textwrap.dedent('''
+            <root main_tree_to_execute="main">
+              <BehaviorTree ID="main">
+                <LogToBagfile prefix="{}" topics="{}" compression="{}">
+                  <Sequence>
+                    <FixRudder depth="1.0" rudder="2.0" speed_knots="3.0"/>
+                    <Delay delay_msec="1000">
+                      <AlwaysSuccess/>
+                    </Delay>
+                  </Sequence>
+                </LogToBagfile>
+              </BehaviorTree>
+            </root>'''.format(bag_name, topic_name, compression_type)))
+            f.flush()
+
+            result = self.mission_interface.load_mission(f.name)
+            self.assertEqual(result.load_state, ReportLoadMissionState.SUCCESS)
+            mission_id = result.mission_id
+
+        self.mission_interface.execute_mission(mission_id)
+
+        def mission_completed():
+            return ReportExecuteMissionState.COMPLETE in \
+                self.mission_interface.execute_mission_state
+        self.assertTrue(wait_for(mission_completed),
+                        msg='Mission did not COMPLETE')
+
+        bag_path = os.path.join(
+            os.path.dirname(rospy.core._log_filename), bag_name)
+        self.assertTrue(os.path.isfile(bag_path), bag_path + ' is missing')
+        with rosbag.Bag(bag_path, 'r') as bag:
+            self.assertEqual(bag.get_compression_info().compression, compression_type)
+            topics = bag.get_type_and_topic_info().topics
+            self.assertEqual(len(topics), 1)
+            name, info = topics.items()[0]
+            self.assertEqual(name, topic_name)
+            self.assertEqual(info.message_count, bag.get_message_count())
+
+    def test_log_to_bagfile(self):
+        self._log_one_topic_to_bagfile(compression_type='none')
+
+    def test_log_to_bz2_compressed_bagfile(self):
+        self._log_one_topic_to_bagfile(compression_type='bz2')
+
+    def test_log_to_lz4_compressed_bagfile(self):
+        self._log_one_topic_to_bagfile(compression_type='lz4')
+
+    def test_log_all_to_bagfile(self):
+        bag_name = 'all_topics.bag'
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(textwrap.dedent('''
+            <root main_tree_to_execute="main">
+              <BehaviorTree ID="main">
+                <LogToBagfile prefix="{}">
+                  <Delay delay_msec="1000">
+                    <AlwaysSuccess/>
+                  </Delay>
+                </LogToBagfile>
+              </BehaviorTree>
+            </root>'''.format(bag_name)))
+            f.flush()
+
+            result = self.mission_interface.load_mission(f.name)
+            self.assertEqual(result.load_state, ReportLoadMissionState.SUCCESS)
+            mission_id = result.mission_id
+
+        self.mission_interface.execute_mission(mission_id)
+
+        def mission_completed():
+            return ReportExecuteMissionState.COMPLETE in \
+                self.mission_interface.execute_mission_state
+        self.assertTrue(wait_for(mission_completed),
+                        msg='Mission did not COMPLETE')
+
+        bag_path = os.path.join(
+            os.path.dirname(rospy.core._log_filename), bag_name)
+        self.assertTrue(os.path.isfile(bag_path), bag_path + ' is missing')
+        with rosbag.Bag(bag_path, 'r') as bag:
+            topics = bag.get_type_and_topic_info().topics
+            self.assertGreaterEqual(len(topics), 1)
+            self.assertIn('/rosout', topics)
+
+
+if __name__ == '__main__':
+    rostest.rosrun('mission_control', 'test_log_to_bagfile_action', TestLogToBagfileAction)

--- a/mission_control/test/test_mission_control_behaviors.test
+++ b/mission_control/test/test_mission_control_behaviors.test
@@ -9,6 +9,7 @@
         -   AttitudeServo
         -   SetAltitudeHeading
         -   GoToWaypoint
+        -   LogToBagfile
   -->
 
   <test test-name="test_fix_rudder_action" pkg="mission_control" type="test_fix_rudder_action.py" time-limit="10.0" />
@@ -16,6 +17,7 @@
   <test test-name="test_set_depth_heading_action" pkg="mission_control" type="test_set_depth_heading_action.py" time-limit="10.0" />
   <test test-name="test_set_altitude_heading_action" pkg="mission_control" type="test_set_altitude_heading_action.py" time-limit="10.0" />
   <test test-name="test_go_to_waypoint_action" pkg="mission_control" type="test_go_to_waypoint_action.py" time-limit="10.0" />
+  <test test-name="test_log_to_bagfile_action" pkg="mission_control" type="test_log_to_bagfile_action.py" time-limit="20.0" />
 
   <!--
       Test if behaviors return Failure state after time out.


### PR DESCRIPTION
# Description

Connected to #142. This patch adds a `LogToBagfile` decorator that can be used record a configurable set of topics for the duration of its subtree (the entire mission if at the root). No separate process is spawned and thus it should be somewhat less resources hungry than `mission_bag_recorder` .

Depends on #153.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

~Tests are yet to be added.~

Run `mission_control` unit tests:

```
catkin_make run_tests_mission_control
```