### PR TITLE
Change fin control angles msg

### DIFF
--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -331,16 +331,18 @@ void AutoPilotNode::mixActuators(double roll, double pitch, double yaw, double t
       degreesToRadians(-rotated_pitch + rotated_yaw + roll),  //  Fin 4 top port
   };
   // Scale down and saturate fin angles if necessary
-  const double angles[] = {fabs(fin_angles[0]), fabs(fin_angles[1]), fabs(fin_angles[2]), //  NOLINT
-                           fabs(fin_angles[3]), max_ctrl_fin_angle_in_radians_};          //NOLINT
-  const double max_angle_in_radians = *std::max_element(std::begin(angles), std::end(angles));
+  const double absolute_fin_angles[] = {
+      fabs(fin_angles[0]), fabs(fin_angles[1]), fabs(fin_angles[2]),  //  NOLINT
+      fabs(fin_angles[3]), max_ctrl_fin_angle_in_radians_};           // NOLINT
+  const double max_angle_in_radians =
+      *std::max_element(std::begin(absolute_fin_angles), std::end(absolute_fin_angles));
   const double scale = max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;
 
   fin_control::SetAngles fin_control_message;
-  for (int i = 0; i < 4; i++)
+  for (int i = 0; i < 4; ++i)
   {
-    fin_control_message.fin_angle_in_radians[i] = saturate(scale * fin_angles[i],
-                                                         max_ctrl_fin_angle_in_radians_);
+    fin_control_message.fin_angle_in_radians[i] =
+        saturate(scale * fin_angles[i], max_ctrl_fin_angle_in_radians_);
   }
 
   fin_control_pub_.publish(fin_control_message);

--- a/fin_control/CMakeLists.txt
+++ b/fin_control/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(
    FILES
    ReportAngle.msg
-   SetAngle.msg
    SetAngles.msg
 )
 

--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -58,7 +58,6 @@
 #include <diagnostic_tools/health_check.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <fin_control/ReportAngle.h>
-#include <fin_control/SetAngle.h>
 #include <fin_control/SetAngles.h>
 #include <health_monitor/ReportFault.h>
 
@@ -87,7 +86,6 @@ class FinControl
   float degreesToRadians(float degrees);
 
   void reportAngleSendTimeout(const ros::TimerEvent& ev);
-  void handleSetAngle(const fin_control::SetAngle::ConstPtr& msg);
   void handleSetAngles(const fin_control::SetAngles::ConstPtr& msg);
 
   double maxCtrlFinAngle;
@@ -99,7 +97,6 @@ class FinControl
   double maxReportAngleRate;
 
   ros::NodeHandle& nodeHandle;
-  ros::Subscriber subscriber_setAngle;
   ros::Subscriber subscriber_setAngles;
   ros::Subscriber subscriber_enableReportAngles;
   diagnostic_tools::DiagnosedPublisher<

--- a/fin_control/msg/SetAngle.msg
+++ b/fin_control/msg/SetAngle.msg
@@ -1,4 +1,0 @@
-uint16  MAX_ANGLE = 40
-uint8   ID
-float64 angle_in_radians
-

--- a/fin_control/msg/SetAngles.msg
+++ b/fin_control/msg/SetAngles.msg
@@ -1,6 +1,2 @@
 uint16  MAX_ANGLE = 40
-float64 f1_angle_in_radians
-float64 f2_angle_in_radians
-float64 f3_angle_in_radians
-float64 f4_angle_in_radians
-
+float64[4] fin_angle_in_radians

--- a/fin_control/src/fin_control.cpp
+++ b/fin_control/src/fin_control.cpp
@@ -101,8 +101,6 @@ FinControl::FinControl(ros::NodeHandle &nodeHandle)
 
   ROS_INFO("fin control constructor enter");
 
-  subscriber_setAngle =
-      nodeHandle.subscribe("/fin_control/set_angle", 10, &FinControl::handleSetAngle, this);
   subscriber_setAngles =
       nodeHandle.subscribe("/fin_control/set_angles", 10, &FinControl::handleSetAngles, this);
 
@@ -312,30 +310,12 @@ void FinControl::handleSetAngles(const fin_control::SetAngles::ConstPtr &msg)
     }
   }
 }
-  void FinControl::handleSetAngle(const fin_control::SetAngle::ConstPtr &msg)
-  {
-    // check for max angle the fins can mechanically handle
-    if (fabs(msg->angle_in_radians) > maxCtrlFinAngle)
-    {
-      ROS_ERROR("Angle set is out of range: %f rad", msg->angle_in_radians);
-      return;
-    }
 
-    float angle_plus_offet = ctrlFinScaleFactor * (msg->angle_in_radians + ctrlFinOffset);
-
-    // Call dynamixel service
-    boost::mutex::scoped_lock lock(m_mutex);
-
-    const char *log;
-    if (!(myWorkBench.goalPosition(msg->ID, angle_plus_offet, &log)))
-      ROS_ERROR("Could not set servo angle for ID %d %s", msg->ID, log);
-  }
-
-  void FinControl::reportAngleSendTimeout(const ros::TimerEvent &ev)
-  {
-    reportAngles();
-    diagnosticsUpdater.update();
-  }
+void FinControl::reportAngleSendTimeout(const ros::TimerEvent &ev)
+{
+  reportAngles();
+  diagnosticsUpdater.update();
+}
 
 }  // namespace robot
 }  // namespace qna

--- a/jaus_ros_bridge/include/ReportFinDeflection.h
+++ b/jaus_ros_bridge/include/ReportFinDeflection.h
@@ -45,7 +45,6 @@
 #define REPORTFINDEFLECTION_H_
 
 #include <fin_control/ReportAngle.h>
-#include <fin_control/SetAngle.h>
 #include "JausMessageOut.h"
 
 // struct FinData{

--- a/jaus_ros_bridge/include/SetFinDeflection.h
+++ b/jaus_ros_bridge/include/SetFinDeflection.h
@@ -47,13 +47,15 @@
 #include <ros/ros.h>
 #include <stdint.h>
 #include "JausMessageIn.h"
+#include <fin_control/SetAngles.h>
 
 class SetFinDeflection : public JausMessageIn {
  private:
   int8_t _finId;              // 1 byte
   int8_t _deflectionAngle;    // 1 byte
   int8_t _deflectionRateCmd;  // 1 byte but not used
-  ros::Publisher _publisher_setAngle;
+  ros::Publisher _publisher_setAngles;
+  std::vector<float> _finAngles;
 
  public:
   void init(ros::NodeHandle* nodeHandle);

--- a/jaus_ros_bridge/src/SetFinDeflection.cpp
+++ b/jaus_ros_bridge/src/SetFinDeflection.cpp
@@ -67,6 +67,9 @@ void SetFinDeflection::ProcessData(char* message)
   _deflectionAngle = (int8_t)message[index++];  // 1 byte
 
   _finAngles.push_back(JausDataManager::degreesToRadians(_deflectionAngle));
+  // Check that the incoming fin ID is the one we expect it to be
+  ROS_ASSERT_MSG(_finAngles.size() == _finId, "Error incoming ID: %d isn't the expected: %ld",
+                 _finId, _finAngles.size());
 
   // Check that all angles were set
   if (_finAngles.size() == 4)


### PR DESCRIPTION
# Description
This PR changes the msg Set Angle msg definition to be used with #151:
- Drop SetAngle msg (that commands 1 fin angle) and replace it with SetAngles (for commanding all fins)
- Merge angles field definition for each fin in SetAngles msg into float64 vector type.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Linter tests are passing

The code was tested on the vehicle
