### PR TITLE
Bug fix - Error Reporting angles to OCU

### DIFF
--- a/jaus_ros_bridge/src/ReportFinDeflection.cpp
+++ b/jaus_ros_bridge/src/ReportFinDeflection.cpp
@@ -93,9 +93,9 @@ void ReportFinDeflection::handleReportAngle(const fin_control::ReportAngle::Cons
 
   if (!TimeToSend(_beginTime, clock())) return;
 
-  if (_finId >= msg->angles_in_radians.size()) return;  // Id out of scope.
+  if (_finId > msg->angles_in_radians.size()) return;  // Id out of scope.
 
-  float f_angle = JausDataManager::radiansToDegrees(msg->angles_in_radians[_finId]);
+  float f_angle = JausDataManager::radiansToDegrees(msg->angles_in_radians[_finId - 1]);
   if (f_angle < 0)
     f_angle -= .5;
   else


### PR DESCRIPTION
# Description
The Jaus Ros Bridge reports wrong angles to the OCU:
- Fin 4 is never updated
- The angles reported are mixed.

## Fixes
- Error in Fin_ID index when jaus ros bridge reports angles. It should be from 0 to 3.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

**The fix was tested on the vehicle**