### PR TITLE
Fix LogToBagfile decorator

### DIFF
--- a/mission_control/src/behaviors/internal/generic_subscription.cpp
+++ b/mission_control/src/behaviors/internal/generic_subscription.cpp
@@ -116,6 +116,7 @@ class TrackingImpl : public GenericSubscriptionImpl
     timer_ = nh.createTimer(
       ros::Duration(1.0),
       boost::bind(&TrackingImpl::trackTopics, this));
+    trackTopics();
   }
 
   void shutdown() override

--- a/mission_control/src/behaviors/log_to_bagfile.cpp
+++ b/mission_control/src/behaviors/log_to_bagfile.cpp
@@ -87,6 +87,21 @@ convertFromString<rosbag::CompressionType>(StringView str)
 namespace mission_control
 {
 
+namespace {
+
+BT::StringView
+strip(const BT::StringView& str)
+{
+  auto start = str.begin();
+  while (std::isspace(*start)) ++start;
+  auto end = str.rbegin();
+  while (std::isspace(*end)) ++end;
+  return BT::StringView(
+    start, std::distance(start, end.base()));
+}
+
+}  // namespace
+
 LogToBagfileNode::Options
 LogToBagfileNode::Options::populateFromPorts(BT::TreeNode * node)
 {
@@ -108,9 +123,9 @@ LogToBagfileNode::Options::populateFromPorts(BT::TreeNode * node)
   {
     if (topics != "all")
     {
-      for (const auto& topic : BT::splitString(topics, ';'))
+      for (const auto& topic : BT::splitString(topics, ','))
       {
-        options.topics.push_back(topic.to_string());
+        options.topics.push_back(strip(topic).to_string());
       }
     }
   }

--- a/mission_control/test/test_log_to_bagfile_action.py
+++ b/mission_control/test/test_log_to_bagfile_action.py
@@ -56,9 +56,9 @@ class TestLogToBagfileAction(unittest.TestCase):
     def setUp(self):
         self.mission_interface = MissionInterface()
 
-    def _log_one_topic_to_bagfile(self, compression_type):
-        bag_name = 'one_topic.{}.bag'.format(compression_type)
-        topic_name = '/mngr/fixed_rudder'
+    def _log_some_topics_to_bagfile(self, compression_type):
+        bag_name = 'some_topics.{}.bag'.format(compression_type)
+        topic_names = ['/mngr/fixed_rudder', '/rosout']
         with tempfile.NamedTemporaryFile() as f:
             f.write(textwrap.dedent('''
             <root main_tree_to_execute="main">
@@ -72,7 +72,7 @@ class TestLogToBagfileAction(unittest.TestCase):
                   </Sequence>
                 </LogToBagfile>
               </BehaviorTree>
-            </root>'''.format(bag_name, topic_name, compression_type)))
+            </root>'''.format(bag_name, ', '.join(topic_names), compression_type)))
             f.flush()
 
             result = self.mission_interface.load_mission(f.name)
@@ -91,21 +91,21 @@ class TestLogToBagfileAction(unittest.TestCase):
             os.path.dirname(rospy.core._log_filename), bag_name)
         self.assertTrue(os.path.isfile(bag_path), bag_path + ' is missing')
         with rosbag.Bag(bag_path, 'r') as bag:
-            self.assertEqual(bag.get_compression_info().compression, compression_type)
+            compression_info = bag.get_compression_info()
+            self.assertEqual(compression_type, compression_info.compression)
             topics = bag.get_type_and_topic_info().topics
-            self.assertEqual(len(topics), 1)
-            name, info = topics.items()[0]
-            self.assertEqual(name, topic_name)
-            self.assertEqual(info.message_count, bag.get_message_count())
+            self.assertEqual(len(topics), len(topic_names))
+            for topic_name in topic_names:
+                self.assertIn(topic_name, topics)
 
     def test_log_to_bagfile(self):
-        self._log_one_topic_to_bagfile(compression_type='none')
+        self._log_some_topics_to_bagfile(compression_type='none')
 
     def test_log_to_bz2_compressed_bagfile(self):
-        self._log_one_topic_to_bagfile(compression_type='bz2')
+        self._log_some_topics_to_bagfile(compression_type='bz2')
 
     def test_log_to_lz4_compressed_bagfile(self):
-        self._log_one_topic_to_bagfile(compression_type='lz4')
+        self._log_some_topics_to_bagfile(compression_type='lz4')
 
     def test_log_all_to_bagfile(self):
         bag_name = 'all_topics.bag'


### PR DESCRIPTION
# Description

This patch amends a few mistakes the `LogToBagfile` decorator, as introduced by #155. Namely: 

- It ensures the `topics` attribute is actually parsed as a comma-separated list
- It strips leading and trailing spaces of each topic in the list
- It updates integration tests to cover the comma separated topic list case
- It ensure an initial topic lookup is made when configured to log `all` 

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Run `mission_control` behavior tests:

```
catkin_make run_tests_mission_control_rostest_test_test_mission_control_behaviors.test
```