### PR TITLE
Autopilot manual negotiation integration

### DIFF
--- a/autopilot/CMakeLists.txt
+++ b/autopilot/CMakeLists.txt
@@ -19,20 +19,6 @@ find_package(catkin REQUIRED COMPONENTS
   mission_control
 )
 
-add_message_files(
-  FILES
-  AutoPilotInControl.msg
-)
-
-generate_messages(
-  DEPENDENCIES
-  fin_control
-  thruster_control
-  jaus_ros_bridge
-  sensor_msgs
-  std_msgs
-)
-
 catkin_package(
  INCLUDE_DIRS include
  CATKIN_DEPENDS auv_interfaces fin_control roscpp rospy std_msgs thruster_control jaus_ros_bridge mission_control

--- a/autopilot/include/autopilot/autopilot.h
+++ b/autopilot/include/autopilot/autopilot.h
@@ -41,7 +41,6 @@
 #ifndef AUTOPILOT_AUTOPILOT_H
 #define AUTOPILOT_AUTOPILOT_H
 
-#include <autopilot/AutoPilotInControl.h>
 #include <math.h>
 #include <ros/ros.h>
 #include <stdint.h>
@@ -59,7 +58,6 @@
 #include "fin_control/ReportAngle.h"
 #include "fin_control/SetAngles.h"
 #include "geodesy/utm.h"
-#include "jaus_ros_bridge/ActivateManualControl.h"
 #include "mission_control/AttitudeServo.h"
 #include "mission_control/DepthHeading.h"
 #include "mission_control/AltitudeHeading.h"
@@ -92,8 +90,6 @@ private:
   void missionHeartbeatCallback(const mission_control::ReportHeartbeat& msg);
   void missionStatusCallback(const mission_control::ReportExecuteMissionState& data);
 
-  void handleActivateManualControl(const jaus_ros_bridge::ActivateManualControl& data);
-
   void mixActuators(double roll, double pitch, double yaw, double thrust);
 
   ros::NodeHandle nh_;
@@ -101,8 +97,6 @@ private:
   ros::Publisher thruster_control_pub_;
   ros::Publisher fin_control_pub_;
   ros::Subscriber state_sub_;
-
-  ros::Subscriber manual_control_sub_;
 
   ros::Subscriber mission_status_sub_;
   ros::Timer mission_heartbeat_timer_;
@@ -120,9 +114,6 @@ private:
   control_toolbox::Pid yaw_pid_controller_;
   control_toolbox::Pid depth_pid_controller_;
   control_toolbox::Pid altitude_pid_controller_;
-
-  ros::Publisher auto_pilot_in_control_pub_;
-  bool auto_pilot_in_control_;
 
   bool state_up_to_date_;
 

--- a/autopilot/msg/AutoPilotInControl.msg
+++ b/autopilot/msg/AutoPilotInControl.msg
@@ -1,2 +1,0 @@
-bool auto_pilot_in_control
-

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -331,16 +331,18 @@ void AutoPilotNode::mixActuators(double roll, double pitch, double yaw, double t
       degreesToRadians(-rotated_pitch + rotated_yaw + roll),  //  Fin 4 top port
   };
   // Scale down and saturate fin angles if necessary
-  const double angles[] = {fabs(fin_angles[0]), fabs(fin_angles[1]), fabs(fin_angles[2]), //  NOLINT
-                           fabs(fin_angles[3]), max_ctrl_fin_angle_in_radians_};          //NOLINT
-  const double max_angle_in_radians = *std::max_element(std::begin(angles), std::end(angles));
+  const double absolute_fin_angles[] = {
+      fabs(fin_angles[0]), fabs(fin_angles[1]), fabs(fin_angles[2]),  //  NOLINT
+      fabs(fin_angles[3]), max_ctrl_fin_angle_in_radians_};           // NOLINT
+  const double max_angle_in_radians =
+      *std::max_element(std::begin(absolute_fin_angles), std::end(absolute_fin_angles));
   const double scale = max_ctrl_fin_angle_in_radians_ / max_angle_in_radians;
 
   fin_control::SetAngles fin_control_message;
-  for (int i = 0; i < 4; i++)
+  for (int i = 0; i < 4; ++i)
   {
-    fin_control_message.fin_angle_in_radians[i] = saturate(scale * fin_angles[i],
-                                                         max_ctrl_fin_angle_in_radians_);
+    fin_control_message.fin_angle_in_radians[i] =
+        saturate(scale * fin_angles[i], max_ctrl_fin_angle_in_radians_);
   }
 
   fin_control_pub_.publish(fin_control_message);

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -522,8 +522,8 @@ void AutoPilotNode::spin()
               ROS_INFO("Capping depth to %f m", desired_depth_);
             }
             // output of depth pid will be input to pitch pid
-            desired_pitch_ = depth_pid_controller_.updatePid(
-                current_depth_ - desired_depth_, r.expectedCycleTime());
+            desired_pitch_ = depth_pid_controller_.updatePid(current_depth_ - desired_depth_,
+                                                             r.expectedCycleTime());
           }
           else if (active_setpoints_ & Setpoint::Altitude)
           {

--- a/autopilot/src/autopilot.cpp
+++ b/autopilot/src/autopilot.cpp
@@ -132,8 +132,8 @@ double relativeAngle(double xb, double yb, double xa, double ya)
 
 AutoPilotNode::AutoPilotNode() : pnh_("~")
 {
-  thruster_control_pub_ = nh_.advertise<thruster_control::SetRPM>("thruster_control/set_rpm", 1);
-  fin_control_pub_ = nh_.advertise<fin_control::SetAngles>("fin_control/set_angles", 1);
+  thruster_control_pub_ = nh_.advertise<thruster_control::SetRPM>("input/autopilot/set_rpm", 1);
+  fin_control_pub_ = nh_.advertise<fin_control::SetAngles>("input/autopilot/set_angles", 1);
 
   control_loop_rate_ = pnh_.param<double>("control_loop_rate", 25.);  // Hz
   minimal_speed_ = pnh_.param<double>("minimal_vehicle_speed", 2.0);  // knots

--- a/cmd_actuators_mux/CMakeLists.txt
+++ b/cmd_actuators_mux/CMakeLists.txt
@@ -1,0 +1,82 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cmd_actuators_mux)
+
+set(NODE_APP_NAME ${PROJECT_NAME}_node)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  fin_control
+  jaus_ros_bridge
+  message_generation
+  mission_control
+  roscpp
+  roslint
+  std_msgs
+  thruster_control
+  pluginlib 
+  nodelet 
+  dynamic_reconfigure
+)
+find_package(PkgConfig)
+pkg_search_module(yaml-cpp REQUIRED yaml-cpp)
+
+if(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif()
+
+# Dynamic reconfigure support
+generate_dynamic_reconfigure_options(cfg/reload.cfg)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}_nodelet
+  CATKIN_DEPENDS fin_control roscpp std_msgs pluginlib nodelet dynamic_reconfigure thruster_control jaus_ros_bridge mission_control
+  DEPENDS yaml-cpp
+ )
+
+roslint_cpp(
+        src/cmd_actuator_mux_nodelet.cpp
+        src/cmd_actuator_subscribers.cpp
+        include/cmd_actuators_mux/cmd_actuator_mux_nodelet.cpp
+        include/cmd_actuators_mux/cmd_actuator_subscribers.cpp
+        include/cmd_actuators_mux/exceptions.h
+)
+
+roslint_add_test()
+
+ ###########
+## Build ##
+###########
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${yaml-cpp_INCLUDE_DIRS}
+)
+
+# Nodelet library
+add_library(${PROJECT_NAME}_nodelet src/cmd_actuator_subscribers.cpp src/cmd_actuator_mux_nodelet.cpp)
+add_dependencies(${PROJECT_NAME}_nodelet ${PROJECT_NAME}_gencfg)
+
+target_link_libraries(${PROJECT_NAME}_nodelet ${catkin_LIBRARIES} ${yaml-cpp_LIBRARIES})
+
+#############
+## Install ##
+#############
+
+install(TARGETS ${PROJECT_NAME}_nodelet
+        DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+install(DIRECTORY plugins
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+install(DIRECTORY launch
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+install(DIRECTORY param
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/cmd_actuators_mux/cfg/reload.cfg
+++ b/cmd_actuators_mux/cfg/reload.cfg
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+PACKAGE = "cmd_actuators_mux"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("yaml_cfg_file", str_t, 0, "Pathname to a yaml file for re-configuration of the mux", "")
+gen.add("yaml_cfg_data", str_t, 0, "Yaml-formatted string for re-configuration of the mux", "")
+
+# Second arg is node name it will run in (doc purposes only), third is generated filename prefix
+exit(gen.generate(PACKAGE, "cmd_actuators_mux", "reload"))

--- a/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_mux_nodelet.h
+++ b/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_mux_nodelet.h
@@ -1,0 +1,189 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  Copyright (c) 2012 Yujin Robot, Daniel Stonier, Jorge Santos
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef CMD_ACTUATORS_MUX_CMD_ACTUATOR_MUX_NODELET_H
+#define CMD_ACTUATORS_MUX_CMD_ACTUATOR_MUX_NODELET_H
+
+#include <dynamic_reconfigure/server.h>
+#include <nodelet/nodelet.h>
+#include <ros/ros.h>
+
+#include <string>
+
+#include "cmd_actuators_mux/cmd_actuator_subscribers.h"
+#include "cmd_actuators_mux/reloadConfig.h"
+#include "fin_control/SetAngles.h"
+#include "thruster_control/SetRPM.h"
+#include "std_msgs/String.h"
+
+namespace cmd_actuator_mux
+{
+class CmdActuatorMuxNodelet : public nodelet::Nodelet
+{
+ public:
+  virtual void onInit();
+
+  CmdActuatorMuxNodelet()
+  {
+    cmd_fin_angles_subs.allowed = VACANT;
+    cmd_set_rpm_subs.allowed = VACANT;
+
+    dynamic_reconfigure_server = NULL;
+  }
+
+  ~CmdActuatorMuxNodelet()
+  {
+    if (dynamic_reconfigure_server != NULL) delete dynamic_reconfigure_server;
+  }
+
+ private:
+  static const unsigned int VACANT =
+      666666; /**< ID for "nobody" active input; anything big is ok */
+  static const unsigned int GLOBAL_TIMER =
+      888888; /**< ID for the global timer functor; anything big is ok */
+
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh;
+
+  /* Pool of topics subscribers */
+  CmdActuatorSubscribers cmd_fin_angles_subs;
+  CmdActuatorSubscribers cmd_set_rpm_subs;
+
+  /* Multiplexed command topics */
+    ros::Publisher fin_angles_output_topic_pub;
+  ros::Publisher set_rpm_output_topic_pub;
+
+  /* Multiplexed command topics names */
+  std::string fin_angles_output_topic_name;
+  std::string set_rpm_output_topic_name;
+
+  /* Currently allowed subscriber */
+  ros::Publisher active_subscriber_pub;
+  std_msgs::String fin_angles_acv_msg;
+  std_msgs::String set_rpm_acv_msg;
+  bool publish_new_subscriber{false};
+
+  /* No messages from any subscriber timeout */
+  ros::Timer fin_angles_common_timer;
+  ros::Timer set_rpm_common_timer;
+
+  /* No messages from any subscriber timeout period */
+  double fin_angles_common_timer_period;
+  double set_rpm_common_timer_period;
+
+  YAML::Node doc;
+
+  void finAnglesTimerCallback(const ros::TimerEvent& event, unsigned int idx);
+  void setRPMTimerCallback(const ros::TimerEvent& event, unsigned int idx);
+  void timerCallbackProcess(CmdActuatorSubscribers& cmd_actuator_subs, const unsigned int& idx);
+
+  void cmdFinAngleCallback(const fin_control::SetAngles::ConstPtr& msg, unsigned int idx);
+  void cmdSetRPMCallback(const thruster_control::SetRPM::ConstPtr& msg, unsigned int idx);
+  bool cmdActuatorCallbackProcess(CmdActuatorSubscribers& cmd_actuator_subs,
+                                  const unsigned int& idx);
+
+  std::string getOutputTopicName(const std::string& label);
+  /*********************
+  ** Dynamic Reconfigure
+  **********************/
+  dynamic_reconfigure::Server<cmd_actuators_mux::reloadConfig>* dynamic_reconfigure_server;
+  dynamic_reconfigure::Server<cmd_actuators_mux::reloadConfig>::CallbackType dynamic_reconfigure_cb;
+  void reloadConfiguration(cmd_actuators_mux::reloadConfig& config, uint32_t unused_level);
+
+  /*********************
+   ** Private Classes
+   **********************/
+  // Functor assigned to each incoming Fin Angle topic to bind it to callback
+  class CmdFinAngleFunctor
+  {
+   private:
+    unsigned int idx;
+    CmdActuatorMuxNodelet* node;
+
+   public:
+    CmdFinAngleFunctor(unsigned int idx, CmdActuatorMuxNodelet* node) : idx(idx), node(node) {}
+
+    void operator()(const fin_control::SetAngles::ConstPtr& msg)
+    {
+      node->cmdFinAngleCallback(msg, idx);
+    }
+  };
+
+  // Functor assigned to each Fin Angle messages source to bind it to timer callback
+  class FinAngleTimerFunctor
+  {
+   private:
+    unsigned int idx;
+    CmdActuatorMuxNodelet* node;
+
+   public:
+    FinAngleTimerFunctor(unsigned int idx, CmdActuatorMuxNodelet* node) : idx(idx), node(node) {}
+
+    void operator()(const ros::TimerEvent& event) { node->finAnglesTimerCallback(event, idx); }
+  };
+
+  // Functor assigned to each incoming Set RPM topic to bind it to callback
+  class CmdSetRPMFunctor
+  {
+   private:
+    unsigned int idx;
+    CmdActuatorMuxNodelet* node;
+
+   public:
+    CmdSetRPMFunctor(unsigned int idx, CmdActuatorMuxNodelet* node) : idx(idx), node(node) {}
+
+    void operator()(const thruster_control::SetRPM::ConstPtr& msg)
+    {
+      node->cmdSetRPMCallback(msg, idx);
+    }
+  };
+
+  // Functor assigned to each Set RPM Angle messages source to bind it to timer callback
+  class SetRPMTimerFunctor
+  {
+   private:
+    unsigned int idx;
+    CmdActuatorMuxNodelet* node;
+
+   public:
+    SetRPMTimerFunctor(unsigned int idx, CmdActuatorMuxNodelet* node) : idx(idx), node(node) {}
+
+    void operator()(const ros::TimerEvent& event) { node->setRPMTimerCallback(event, idx); }
+  };
+};
+
+}  // namespace cmd_actuator_mux
+
+#endif  //  CMD_ACTUATORS_MUX_CMD_ACTUATOR_MUX_NODELET_H

--- a/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_mux_nodelet.h
+++ b/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_mux_nodelet.h
@@ -82,7 +82,7 @@ class CmdActuatorMuxNodelet : public nodelet::Nodelet
   CmdActuatorSubscribers cmd_set_rpm_subs;
 
   /* Multiplexed command topics */
-    ros::Publisher fin_angles_output_topic_pub;
+  ros::Publisher fin_angles_output_topic_pub;
   ros::Publisher set_rpm_output_topic_pub;
 
   /* Multiplexed command topics names */

--- a/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_mux_nodelet.h
+++ b/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_mux_nodelet.h
@@ -93,7 +93,6 @@ class CmdActuatorMuxNodelet : public nodelet::Nodelet
   ros::Publisher active_subscriber_pub;
   std_msgs::String fin_angles_acv_msg;
   std_msgs::String set_rpm_acv_msg;
-  bool publish_new_subscriber{false};
 
   /* No messages from any subscriber timeout */
   ros::Timer fin_angles_common_timer;

--- a/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_subscribers.h
+++ b/cmd_actuators_mux/include/cmd_actuators_mux/cmd_actuator_subscribers.h
@@ -1,0 +1,103 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  Copyright (c) 2012 Yujin Robot, Daniel Stonier, Jorge Santos
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef CMD_ACTUATORS_MUX_CMD_ACTUATOR_SUBSCRIBERS_H
+#define CMD_ACTUATORS_MUX_CMD_ACTUATOR_SUBSCRIBERS_H
+
+#include <ros/ros.h>
+#include <yaml-cpp/yaml.h>
+#include <string>
+#include <vector>
+
+#ifdef HAVE_NEW_YAMLCPP
+// The >> operator disappeared in yaml-cpp 0.5, so this function is
+// added to provide support for code written under the yaml-cpp 0.3 API.
+template <typename T>
+void operator>>(const YAML::Node& node, T& i)
+{
+  i = node.as<T>();
+}
+#endif
+
+namespace cmd_actuator_mux
+{
+class CmdActuatorSubscribers
+{
+ public:
+  class CmdActuatorSubs
+  {
+   public:
+    unsigned int idx;       /**< Index; assigned according to the order on YAML file */
+    std::string name;       /**< Descriptive name; must be unique to this subscriber */
+    std::string topic;      /**< The name of the topic */
+    ros::Subscriber subs;   /**< The subscriber itself */
+    ros::Timer timer;       /**< No incoming messages timeout */
+    double timeout;         /**< Timer's timeout, in seconds  */
+    unsigned int priority;  /**< UNIQUE integer from 0 (lowest priority) to MAX_INT */
+    std::string short_desc; /**< Short description (optional) */
+    bool active;            /**< Whether this source is active */
+
+    explicit CmdActuatorSubs(unsigned int idx) : idx(idx), active(false) {}
+    ~CmdActuatorSubs() {}
+
+    /* Fill attributes with a YAML node content */
+    void operator<<(const YAML::Node& node);
+  };
+
+  CmdActuatorSubscribers() {}
+  ~CmdActuatorSubscribers() {}
+
+  std::vector<std::shared_ptr<CmdActuatorSubs>>::size_type size() { return list.size(); }
+  std::shared_ptr<CmdActuatorSubs>& operator[](unsigned int idx) { return list[idx]; }
+
+  /**
+   * @brief Configures the subscribers from a yaml file.
+   *
+   * @exception FileNotFoundException : yaml file not found
+   * @exception YamlException : problem parsing the yaml
+   * @exception EmptyCfgException : empty configuration file
+   * @param node : node holding all the subscriber configuration
+   */
+  void configure(const YAML::Node& node);
+
+  unsigned int allowed;
+
+ private:
+  std::vector<std::shared_ptr<CmdActuatorSubs>> list;
+};
+
+}  // namespace cmd_actuator_mux
+
+#endif  //  CMD_ACTUATORS_MUX_CMD_ACTUATOR_SUBSCRIBERS_H

--- a/cmd_actuators_mux/include/cmd_actuators_mux/exceptions.h
+++ b/cmd_actuators_mux/include/cmd_actuators_mux/exceptions.h
@@ -1,0 +1,68 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  Copyright (c) 2012 Yujin Robot, Daniel Stonier, Jorge Santos
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef CMD_ACTUATORS_MUX_EXCEPTIONS_H
+#define CMD_ACTUATORS_MUX_EXCEPTIONS_H
+
+#include <exception>
+#include <string>
+
+namespace cmd_actuator_mux
+{
+class FileNotFoundException : public std::runtime_error
+{
+ public:
+  explicit FileNotFoundException(const std::string& msg) : std::runtime_error(msg) {}
+  virtual ~FileNotFoundException() throw() {}
+};
+
+class EmptyCfgException : public std::runtime_error
+{
+ public:
+  explicit EmptyCfgException(const std::string& msg) : std::runtime_error(msg) {}
+  virtual ~EmptyCfgException() throw() {}
+};
+
+class YamlException : public std::runtime_error
+{
+ public:
+  explicit YamlException(const std::string& msg) : std::runtime_error(msg) {}
+  virtual ~YamlException() throw() {}
+};
+
+}  // namespace cmd_actuator_mux
+
+#endif  //  CMD_ACTUATORS_MUX_EXCEPTIONS_H

--- a/cmd_actuators_mux/launch/cmd_actuators_mux.launch
+++ b/cmd_actuators_mux/launch/cmd_actuators_mux.launch
@@ -1,0 +1,11 @@
+<launch>
+  <arg name="nodelet_manager_name" value="nodelet_manager" />
+  <arg name="config_file" value="$(find cmd_actuators_mux)/param/actuator_mux.yaml" />
+
+  <!-- nodelet manager -->
+  <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager_name)" args="manager" />
+
+  <node pkg="nodelet" type="nodelet" name="CmdActuatorMuxNodelet" args="load cmd_actuators_mux/CmdActuatorMuxNodelet $(arg nodelet_manager_name)">
+    <param name="yaml_cfg_file" value="$(arg config_file)" />
+  </node>
+</launch>

--- a/cmd_actuators_mux/package.xml
+++ b/cmd_actuators_mux/package.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>cmd_actuators_mux</name>
+  <version>0.0.0</version>
+  <description>The command actuator mux package</description>
+
+  <maintainer email="Christopher.Scianna@us.QinetiQ.com">Christopher Scianna</maintainer>
+  <maintainer email="aschapiro@ekumenlabs.com">Alvaro Schapiro</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>fin_control</build_depend>
+  <build_depend>jaus_ros_bridge</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>mission_control</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>roslint</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>thruster_control</build_depend>
+  <build_depend>yaml-cpp</build_depend>
+  <build_depend>nodelet</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_export_depend>fin_control</build_export_depend>
+  <build_export_depend>jaus_ros_bridge</build_export_depend>
+  <build_export_depend>mission_control</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>thruster_control</build_export_depend>
+  <build_export_depend>yaml-cpp</build_export_depend>
+  <exec_depend>fin_control</exec_depend>
+  <exec_depend>jaus_ros_bridge</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>mission_control</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>thruster_control</exec_depend>
+  <exec_depend>yaml-cpp</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>nodelet</exec_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
+
+  <export>
+    <nodelet plugin="${prefix}/plugins/nodelets.xml" />
+  </export>
+</package>

--- a/cmd_actuators_mux/param/actuator_mux.yaml
+++ b/cmd_actuators_mux/param/actuator_mux.yaml
@@ -1,0 +1,36 @@
+# Individual subscriber configuration:
+#   name:           Source name
+#   topic:          The topic that provides  messages
+#   timeout:        Time in seconds without incoming messages to consider this topic inactive
+#   priority:       Priority: an UNIQUE unsigned integer from 0 (lowest) to MAX_INT 
+#   short_desc:     Short description (optional)
+
+
+# Fin Angles
+fin_angles_subscribers:
+  - name:        "Autopilot"
+    topic:       "input/autopilot/set_angles"
+    timeout:     0.1
+    priority:    0
+    short_desc:  "Command sent by the Autopilot controller to the fin controller"
+  - name:        "Jaus Ros Bridge"
+    topic:       "input/jausRosBridge/set_angles"
+    timeout:     0.5
+    priority:    1
+    short_desc:  "Commands sent by the Jaus ROS Bridge to the fin controller"
+fin_angles_publisher:       "fin_control/set_angles"
+
+
+# Thruster
+set_rpm_subscribers:
+  - name:        "Autopilot"
+    topic:       "input/autopilot/set_rpm"
+    timeout:     0.1
+    priority:    0
+    short_desc:  "Command sent by the Autopilot controller to the Thruster Controller"
+  - name:        "Jaus Ros Bridge"
+    topic:       "input/jaus_ros_bridge/set_rpm"
+    timeout:     0.5
+    priority:    1
+    short_desc:  "Command sent by the Jaus ROS Bridge to the Thruster Controller"
+set_rpm_publisher:       "thruster_control/set_rpm"

--- a/cmd_actuators_mux/param/actuator_mux.yaml
+++ b/cmd_actuators_mux/param/actuator_mux.yaml
@@ -14,7 +14,7 @@ fin_angles_subscribers:
     priority:    0
     short_desc:  "Command sent by the Autopilot controller to the fin controller"
   - name:        "Jaus Ros Bridge"
-    topic:       "input/jausRosBridge/set_angles"
+    topic:       "input/jaus_ros_bridge/set_angles"
     timeout:     0.5
     priority:    1
     short_desc:  "Commands sent by the Jaus ROS Bridge to the fin controller"

--- a/cmd_actuators_mux/plugins/nodelets.xml
+++ b/cmd_actuators_mux/plugins/nodelets.xml
@@ -1,0 +1,9 @@
+<library path="lib/libcmd_actuators_mux_nodelet">
+  <class name="cmd_actuators_mux/CmdActuatorMuxNodelet"
+         type="cmd_actuator_mux::CmdActuatorMuxNodelet"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      Implementation for the command actuators multiplexer as a nodelet.
+    </description>
+  </class>
+</library>

--- a/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
+++ b/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
@@ -397,9 +397,10 @@ void CmdActuatorMuxNodelet::reloadConfiguration(cmd_actuators_mux::reloadConfig&
 
   // check that the both arrays have the same length 
   ROS_ASSERT_MSG(cmd_set_rpm_subs.size()==(cmd_fin_angles_subs.size()),
-                   "Different amount of inputs between SetRPM Subscriber (%ld) and "
-                   "Fin_Angles Subscribers (%ld) in YAML file:",
-                   cmd_set_rpm_subs.size(), cmd_fin_angles_subs.size());
+                   "Different amount of inputs between SetRPM Subscriber (%d) and "
+                   "Fin_Angles Subscribers (%d) in YAML file:",
+                   static_cast<int>(cmd_set_rpm_subs.size()),
+                   static_cast<int>(cmd_fin_angles_subs.size()));
 
   // check that the subscribers input have the same name in YAML
   for (int i = 0; i < cmd_set_rpm_subs.size(); i++)

--- a/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
+++ b/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
@@ -64,11 +64,7 @@ void CmdActuatorMuxNodelet::cmdFinAngleCallback(const fin_control::SetAngles::Co
     // Wait until both RPM and Fin commands come from the same source
     if (set_rpm_acv_msg.data == fin_angles_acv_msg.data)
     {
-      if (publish_new_subscriber)
-      {
-        active_subscriber_pub.publish(fin_angles_acv_msg);
-        publish_new_subscriber = false;
-      }
+      active_subscriber_pub.publish(fin_angles_acv_msg);
       fin_angles_output_topic_pub.publish(msg);
     }
     else
@@ -91,11 +87,7 @@ void CmdActuatorMuxNodelet::cmdSetRPMCallback(const thruster_control::SetRPM::Co
     // waint until both, RPM and Fin commands come from the same source
     if (set_rpm_acv_msg.data == fin_angles_acv_msg.data)
     {
-      if (publish_new_subscriber)
-      {
-        active_subscriber_pub.publish(set_rpm_acv_msg);
-        publish_new_subscriber = false;
-      }
+      active_subscriber_pub.publish(set_rpm_acv_msg);
       set_rpm_output_topic_pub.publish(msg);
     }
     else
@@ -121,7 +113,6 @@ bool CmdActuatorMuxNodelet::cmdActuatorCallbackProcess(CmdActuatorSubscribers& c
     if (cmd_actuator_subs.allowed != idx)
     {
       cmd_actuator_subs.allowed = idx;
-      publish_new_subscriber = true;
     }
     return true;
   }

--- a/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
+++ b/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
@@ -92,8 +92,8 @@ void CmdActuatorMuxNodelet::cmdSetRPMCallback(const thruster_control::SetRPM::Co
     }
     else
       ROS_DEBUG_STREAM("RPM and fin angles values come from different source"
-                       << " - set RPM source: " << cmd_set_rpm_subs[idx]->name
-                       << " - set Fin Angles source: " << cmd_fin_angles_subs[idx]->name);
+                       << " - set RPM source: " << set_rpm_acv_msg.data
+                       << " - set Fin Angles source: " << fin_angles_acv_msg.data);
   }
 }
 

--- a/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
+++ b/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
@@ -1,0 +1,435 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  Copyright (c) 2012 Yujin Robot, Daniel Stonier, Jorge Santos
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "cmd_actuators_mux/cmd_actuator_mux_nodelet.h"
+
+#include <pluginlib/class_list_macros.h>
+#include <std_msgs/String.h>
+
+#include <fstream>
+#include <string>
+
+#include "cmd_actuators_mux/exceptions.h"
+
+namespace cmd_actuator_mux
+{
+/*****************************************************************************
+ ** Implementation
+ *****************************************************************************/
+
+void CmdActuatorMuxNodelet::cmdFinAngleCallback(const fin_control::SetAngles::ConstPtr& msg,
+                                                unsigned int idx)
+{
+  // Reset general timer
+  fin_angles_common_timer.stop();
+  fin_angles_common_timer.start();
+
+  if (cmdActuatorCallbackProcess(cmd_fin_angles_subs, idx))
+  {
+    // The fin angle input has changed from an input to another
+    fin_angles_acv_msg.data = cmd_fin_angles_subs[idx]->name;
+
+    // Wait until both RPM and Fin commands come from the same source
+    if (set_rpm_acv_msg.data == fin_angles_acv_msg.data)
+    {
+      if (publish_new_subscriber)
+      {
+        active_subscriber_pub.publish(fin_angles_acv_msg);
+        publish_new_subscriber = false;
+      }
+      fin_angles_output_topic_pub.publish(msg);
+    }
+    else
+      ROS_DEBUG_STREAM("RPM and fin angles values come from different source"
+                       << " - set RPM source: " << cmd_set_rpm_subs[idx]->name
+                       << " - set Fin Angles source: " << cmd_fin_angles_subs[idx]->name);
+  }
+}
+
+void CmdActuatorMuxNodelet::cmdSetRPMCallback(const thruster_control::SetRPM::ConstPtr& msg,
+                                              unsigned int idx)
+{
+  set_rpm_common_timer.stop();
+  set_rpm_common_timer.start();
+
+  if (cmdActuatorCallbackProcess(cmd_set_rpm_subs, idx))
+  {
+    set_rpm_acv_msg.data = cmd_set_rpm_subs[idx]->name;
+
+    // waint until both, RPM and Fin commands come from the same source
+    if (set_rpm_acv_msg.data == fin_angles_acv_msg.data)
+    {
+      if (publish_new_subscriber)
+      {
+        active_subscriber_pub.publish(set_rpm_acv_msg);
+        publish_new_subscriber = false;
+      }
+      set_rpm_output_topic_pub.publish(msg);
+    }
+    else
+      ROS_DEBUG_STREAM("RPM and fin angles values come from different source"
+                       << " - set RPM source: " << cmd_set_rpm_subs[idx]->name
+                       << " - set Fin Angles source: " << cmd_fin_angles_subs[idx]->name);
+  }
+}
+
+bool CmdActuatorMuxNodelet::cmdActuatorCallbackProcess(CmdActuatorSubscribers& cmd_actuator_subs,
+                                                       const unsigned int& idx)
+{
+  // Reset timer for this source
+  cmd_actuator_subs[idx]->timer.stop();
+  cmd_actuator_subs[idx]->timer.start();
+  cmd_actuator_subs[idx]->active = true;  // obviously his source is sending commands, so active
+
+  // Give permit to publish to this source if it's the only active or is
+  // already allowed or has higher priority that the currently allowed
+  if ((cmd_actuator_subs.allowed == VACANT) || (cmd_actuator_subs.allowed == idx) ||
+      (cmd_actuator_subs[idx]->priority > cmd_actuator_subs[cmd_actuator_subs.allowed]->priority))
+  {
+    if (cmd_actuator_subs.allowed != idx)
+    {
+      cmd_actuator_subs.allowed = idx;
+      publish_new_subscriber = true;
+    }
+    return true;
+  }
+  return false;
+}
+
+void CmdActuatorMuxNodelet::finAnglesTimerCallback(const ros::TimerEvent& event, unsigned int idx)
+{
+  timerCallbackProcess(cmd_fin_angles_subs, idx);
+}
+
+void CmdActuatorMuxNodelet::setRPMTimerCallback(const ros::TimerEvent& event, unsigned int idx)
+{
+  timerCallbackProcess(cmd_set_rpm_subs, idx);
+}
+
+void CmdActuatorMuxNodelet::timerCallbackProcess(CmdActuatorSubscribers& cmd_actuator_subs,
+                                                 const unsigned int& idx)
+{
+  if (cmd_actuator_subs.allowed == idx ||
+      (idx == GLOBAL_TIMER && cmd_actuator_subs.allowed != VACANT))
+  {
+    if (idx == GLOBAL_TIMER)
+    {
+      // No messages timeout happened for ANYONE, so last active source got stuck without further
+      // messages; not a big problem, just dislodge it; but possibly reflect a problem in the
+      // controller
+      NODELET_WARN("Actuator : No messages from ANY input received");
+      NODELET_WARN("Actuator: %s dislodged due to general timeout",
+                   cmd_actuator_subs[cmd_actuator_subs.allowed]->name.c_str());
+    }
+
+    // No messages timeout happened to currently active source, so...
+    cmd_actuator_subs.allowed = VACANT;
+
+    // ...notify the world that nobody is publishing; its vacant
+    std_msgs::StringPtr acv_msg(new std_msgs::String);
+    acv_msg->data = "idle";
+    active_subscriber_pub.publish(acv_msg);
+  }
+
+  if (idx != GLOBAL_TIMER) cmd_actuator_subs[idx]->active = false;
+}
+
+void CmdActuatorMuxNodelet::onInit()
+{
+  nh = this->getNodeHandle();
+  pnh = this->getPrivateNodeHandle();
+
+  /*********************
+  ** Dynamic Reconfigure
+  **********************/
+  dynamic_reconfigure_cb = boost::bind(&CmdActuatorMuxNodelet::reloadConfiguration, this, _1, _2);
+  dynamic_reconfigure_server =
+      new dynamic_reconfigure::Server<cmd_actuators_mux::reloadConfig>(pnh);
+  dynamic_reconfigure_server->setCallback(dynamic_reconfigure_cb);
+
+  active_subscriber_pub = pnh.advertise<std_msgs::String>("active_subscriber", 1, true);
+
+  // Notify the world that by now nobody is publishing on yet
+  std_msgs::StringPtr active_msg(new std_msgs::String);
+  active_msg->data = "idle";
+  active_subscriber_pub.publish(active_msg);
+
+  // could use a call to reloadConfiguration here, but it seems to automatically call it once with
+  // defaults anyway.
+  NODELET_DEBUG("Command Actuator Mux : successfully initialized");
+}
+
+void CmdActuatorMuxNodelet::reloadConfiguration(cmd_actuators_mux::reloadConfig& config,
+                                                uint32_t unused_level)
+{
+  std::unique_ptr<std::istream> is;
+
+  // Configuration can come directly as a yaml-formatted string or as a file path,
+  // but not both, so we give priority to the first option
+  if (config.yaml_cfg_data.size() > 0)
+  {
+    is.reset(new std::istringstream(config.yaml_cfg_data));
+  }
+  else
+  {
+    std::string yaml_cfg_file;
+    if (config.yaml_cfg_file == "")
+    {
+      // typically fired on startup, so look for a parameter to set a default
+      pnh.getParam("yaml_cfg_file", yaml_cfg_file);
+    }
+    else
+    {
+      yaml_cfg_file = config.yaml_cfg_file;
+    }
+
+    is.reset(new std::ifstream(yaml_cfg_file.c_str(), std::ifstream::in));
+    if (is->good() == false)
+    {
+      NODELET_ERROR_STREAM("Fin Angle Mux : configuration file not found [" << yaml_cfg_file
+                                                                            << "]");
+      return;
+    }
+  }
+
+  /*********************
+  ** Yaml File Parsing
+  **********************/
+
+#ifdef HAVE_NEW_YAMLCPP
+  doc = YAML::Load(*is);
+#else
+  YAML::Parser parser(*is);
+  parser.GetNextDocument(doc);
+#endif
+
+  /*********************
+  ** Fin Angles
+  **********************/
+
+  /******** Publisher  *******************************/
+  std::string output_name = getOutputTopicName("fin_angles_publisher");
+  if (fin_angles_output_topic_name != output_name)
+  {
+    fin_angles_output_topic_name = output_name;
+    fin_angles_output_topic_pub =
+        nh.advertise<fin_control::SetAngles>(fin_angles_output_topic_name, 10);
+    NODELET_DEBUG_STREAM("Subscribe to output topic '" << output_name << "'");
+  }
+  else
+  {
+    NODELET_DEBUG_STREAM("No need to re-subscribe to output topic '" << output_name << "'");
+  }
+
+  /******** Input Subscribers *******************************/
+
+  try
+  {
+    cmd_fin_angles_subs.configure(doc["fin_angles_subscribers"]);
+  }
+  catch (EmptyCfgException& e)
+  {
+    NODELET_WARN_STREAM(
+        "yaml configured zero subscribers, check yaml content: fin_angles_subscribers");
+  }
+  catch (YamlException& e)
+  {
+    NODELET_ERROR_STREAM("fin_angles_subscribers: yaml parsing problem [" << std::string(e.what())
+                                                                          << "]");
+  }
+
+  // (Re)create subscribers whose topic is invalid: new ones and those with changed names
+  double longest_timeout = 0.0;
+  for (unsigned int i = 0; i < cmd_fin_angles_subs.size(); i++)
+  {
+    if (!cmd_fin_angles_subs[i]->subs)
+    {
+      cmd_fin_angles_subs[i]->subs = nh.subscribe<fin_control::SetAngles>(
+          cmd_fin_angles_subs[i]->topic, 10, CmdFinAngleFunctor(i, this));
+      NODELET_DEBUG("Fin Angle Mux : subscribed to '%s' on topic '%s'. pr: %d, to: %.2f",
+                    cmd_fin_angles_subs[i]->name.c_str(), cmd_fin_angles_subs[i]->topic.c_str(),
+                    cmd_fin_angles_subs[i]->priority, cmd_fin_angles_subs[i]->timeout);
+    }
+    else
+    {
+      NODELET_DEBUG_STREAM("Fin Angle Mux : no need to re-subscribe to input topic '"
+                           << cmd_fin_angles_subs[i]->topic << "'");
+    }
+
+    if (!cmd_fin_angles_subs[i]->timer)
+    {
+      // Create (stopped by now) a one-shot timer for every subscriber, if it doesn't exist yet
+      cmd_fin_angles_subs[i]->timer =
+          pnh.createTimer(ros::Duration(cmd_fin_angles_subs[i]->timeout),
+                          FinAngleTimerFunctor(i, this), true, false);
+    }
+
+    if (cmd_fin_angles_subs[i]->timeout > longest_timeout)
+      longest_timeout = cmd_fin_angles_subs[i]->timeout;
+  }
+
+  if (!fin_angles_common_timer)
+  {
+    // Create another timer for  messages from any source, so we can
+    // dislodge last active source if it gets stuck without further messages
+    fin_angles_common_timer_period = longest_timeout * 2.0;
+    fin_angles_common_timer =
+        pnh.createTimer(ros::Duration(fin_angles_common_timer_period),
+                        FinAngleTimerFunctor(GLOBAL_TIMER, this), true, false);
+  }
+  else if (longest_timeout != (fin_angles_common_timer_period / 2.0))
+  {
+    // Longest timeout changed; just update existing timer period
+    fin_angles_common_timer_period = longest_timeout * 2.0;
+    fin_angles_common_timer.setPeriod(ros::Duration(fin_angles_common_timer_period));
+  }
+
+  NODELET_INFO_STREAM("Fin Angle Mux : (re)configured");
+
+  /*********************
+  ** Thruster / Set RPM
+  **********************/
+
+  /******** Publisher  *******************************/
+  output_name = getOutputTopicName("set_rpm_publisher");
+  if (set_rpm_output_topic_name != output_name)
+  {
+    set_rpm_output_topic_name = output_name;
+    set_rpm_output_topic_pub =
+        nh.advertise<thruster_control::SetRPM>(set_rpm_output_topic_name, 10);
+    NODELET_DEBUG_STREAM("Subscribe to output topic '" << output_name << "'");
+  }
+  else
+  {
+    NODELET_DEBUG_STREAM("No need to re-subscribe to output topic '" << output_name << "'");
+  }
+
+  /******** Input Subscribers *******************************/
+  try
+  {
+    cmd_set_rpm_subs.configure(doc["set_rpm_subscribers"]);
+  }
+  catch (EmptyCfgException& e)
+  {
+    NODELET_WARN_STREAM(
+        "yaml configured zero subscribers, check yaml content: set_rpm_subscribers");
+  }
+  catch (YamlException& e)
+  {
+    NODELET_ERROR_STREAM("set_rpm_subscribers: yaml parsing problem [" << std::string(e.what())
+                                                                       << "]");
+  }
+
+  double set_rpm_longest_timeout = 0.0;
+  for (unsigned int i = 0; i < cmd_set_rpm_subs.size(); i++)
+  {
+    if (!cmd_set_rpm_subs[i]->subs)
+    {
+      cmd_set_rpm_subs[i]->subs = nh.subscribe<thruster_control::SetRPM>(
+          cmd_set_rpm_subs[i]->topic, 10, CmdSetRPMFunctor(i, this));
+      NODELET_DEBUG("Thruster Set RPM Mux : subscribed to '%s' on topic '%s'. pr: %d, to: %.2f",
+                    cmd_set_rpm_subs[i]->name.c_str(), cmd_set_rpm_subs[i]->topic.c_str(),
+                    cmd_set_rpm_subs[i]->priority, cmd_set_rpm_subs[i]->timeout);
+    }
+    else
+    {
+      NODELET_DEBUG_STREAM("Thruster Set RPM Mux : no need to re-subscribe to input topic '"
+                           << cmd_set_rpm_subs[i]->topic << "'");
+    }
+
+    if (!cmd_set_rpm_subs[i]->timer)
+    {
+      // Create (stopped by now) a one-shot timer for every subscriber, if it doesn't exist yet
+      cmd_set_rpm_subs[i]->timer = pnh.createTimer(ros::Duration(cmd_set_rpm_subs[i]->timeout),
+                                                   SetRPMTimerFunctor(i, this), true, false);
+    }
+
+    if (cmd_set_rpm_subs[i]->timeout > set_rpm_longest_timeout)
+      set_rpm_longest_timeout = cmd_set_rpm_subs[i]->timeout;
+  }
+
+  if (!set_rpm_common_timer)
+  {
+    // Create another timer for  messages from any source, so we can
+    // dislodge last active source if it gets stuck without further messages
+    set_rpm_common_timer_period = longest_timeout * 2.0;
+    set_rpm_common_timer = pnh.createTimer(ros::Duration(set_rpm_common_timer_period),
+                                           SetRPMTimerFunctor(GLOBAL_TIMER, this), true, false);
+  }
+  else if (longest_timeout != (set_rpm_common_timer_period / 2.0))
+  {
+    // Longest timeout changed; just update existing timer period
+    set_rpm_common_timer_period = longest_timeout * 2.0;
+    set_rpm_common_timer.setPeriod(ros::Duration(set_rpm_common_timer_period));
+  }
+
+  // check that the both arrays have the same length 
+  ROS_ASSERT_MSG(cmd_set_rpm_subs.size()==(cmd_fin_angles_subs.size()),
+                   "Different amount of inputs between SetRPM Subscriber (%ld) and "
+                   "Fin_Angles Subscribers (%ld) in YAML file:",
+                   cmd_set_rpm_subs.size(), cmd_fin_angles_subs.size());
+
+  // check that the subscribers input have the same name in YAML
+  for (int i = 0; i < cmd_set_rpm_subs.size(); i++)
+  {
+    ROS_ASSERT_MSG(!cmd_set_rpm_subs[i]->name.compare(cmd_fin_angles_subs[i]->name),
+                   "Subscribers from same input must have equal names in YAML file:"
+                   "\nID: %d - Subscriber 1 name: %s - Subscriber 2 name: %s",
+                   i, cmd_set_rpm_subs[i]->name.c_str(), cmd_fin_angles_subs[i]->name.c_str());
+  }
+}
+
+std::string CmdActuatorMuxNodelet::getOutputTopicName(const std::string& label)
+{
+  std::string output_name("output");
+#ifdef HAVE_NEW_YAMLCPP
+  if (doc[label])
+  {
+    doc[label] >> output_name;
+  }
+#else
+  const YAML::Node* node = doc.FindValue(label);
+  if (node != NULL)
+  {
+    *node >> output_name;
+  }
+#endif
+
+  return output_name;
+}
+
+}  // namespace cmd_actuator_mux
+
+PLUGINLIB_EXPORT_CLASS(cmd_actuator_mux::CmdActuatorMuxNodelet, nodelet::Nodelet);

--- a/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
+++ b/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
@@ -73,8 +73,8 @@ void CmdActuatorMuxNodelet::cmdFinAngleCallback(const fin_control::SetAngles::Co
     }
     else
       ROS_DEBUG_STREAM("RPM and fin angles values come from different source"
-                       << " - set RPM source: " << cmd_set_rpm_subs[idx]->name
-                       << " - set Fin Angles source: " << cmd_fin_angles_subs[idx]->name);
+                       << " - set RPM source: " << set_rpm_acv_msg.data
+                       << " - set Fin Angles source: " << fin_angles_acv_msg.data);
   }
 }
 

--- a/cmd_actuators_mux/src/cmd_actuator_subscribers.cpp
+++ b/cmd_actuators_mux/src/cmd_actuator_subscribers.cpp
@@ -1,0 +1,129 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  Copyright (c) 2012 Yujin Robot, Daniel Stonier, Jorge Santos
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "cmd_actuators_mux/cmd_actuator_subscribers.h"
+
+#include <fstream>
+#include <vector>
+#include <string>
+
+#include "cmd_actuators_mux/exceptions.h"
+
+namespace cmd_actuator_mux
+{
+void CmdActuatorSubscribers::CmdActuatorSubs::operator<<(const YAML::Node& node)
+{
+  // Fill attributes with a YAML node content
+  double new_timeout;
+  std::string new_topic;
+  node["name"] >> name;
+  node["topic"] >> new_topic;
+  node["timeout"] >> new_timeout;
+  node["priority"] >> priority;
+#ifdef HAVE_NEW_YAMLCPP
+  if (node["short_desc"])
+  {
+#else
+  if (node.FindValue("short_desc") != NULL)
+  {
+#endif
+    node["short_desc"] >> short_desc;
+  }
+
+  if (new_topic != topic)
+  {
+    // Shutdown the topic if the name has changed so it gets recreated on configuration reload
+    // In the case of new subscribers, topic is empty and shutdown has just no effect
+    topic = new_topic;
+    subs.shutdown();
+  }
+
+  if (new_timeout != timeout)
+  {
+    // Change timer period if the timeout changed
+    timeout = new_timeout;
+    timer.setPeriod(ros::Duration(timeout));
+  }
+}
+
+void CmdActuatorSubscribers::configure(const YAML::Node& node)
+{
+  try
+  {
+    if (node.size() == 0)
+    {
+      throw EmptyCfgException("Configuration is empty");
+    }
+
+    std::vector<std::shared_ptr<CmdActuatorSubs>> new_list(node.size());
+    for (unsigned int i = 0; i < node.size(); i++)
+    {
+      // Parse entries on YAML
+      std::string new_subs_name = node[i]["name"].Scalar();
+      auto old_subs = std::find_if(list.begin(), list.end(),
+                                   [&new_subs_name](const std::shared_ptr<CmdActuatorSubs>& subs) {   //NOLINT
+                                     return subs->name == new_subs_name;
+                                   });  //NOLINT
+      if (old_subs != list.end())
+      {
+        // For names already in the subscribers list, retain current object so we don't re-subscribe
+        // to the topic
+        new_list[i] = *old_subs;
+      }
+      else
+      {
+        new_list[i] = std::make_shared<CmdActuatorSubs>(i);
+      }
+      // update existing or new object with the new configuration
+      *new_list[i] << node[i];
+    }
+
+    list = new_list;
+  }
+  catch (EmptyCfgException& e)
+  {
+    throw e;
+  }
+  catch (YAML::ParserException& e)
+  {
+    throw YamlException(e.what());
+  }
+  catch (YAML::RepresentationException& e)
+  {
+    throw YamlException(e.what());
+  }
+}
+
+}  // namespace cmd_actuator_mux

--- a/cmd_actuators_mux/test/autopilot_publisher.py
+++ b/cmd_actuators_mux/test/autopilot_publisher.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import unittest
+import math
+import rosnode
+import rospy
+import rostest
+from fin_control.msg import SetAngles
+from thruster_control.msg import SetRPM
+
+if __name__ == '__main__':
+    rospy.init_node('test_autopilot_publisher')
+    angleMsg = SetAngles()
+    rpmMsg = SetRPM ()
+
+    simulated_autopilot_angles = rospy.Publisher(
+        '/input/autopilot/set_angles',
+        SetAngles,
+        queue_size=1)
+    simulated_autopilot_RPM = rospy.Publisher(
+        '/input/autopilot/set_rpm',
+        SetRPM,
+        queue_size=1)
+    
+    rate = rospy.Rate(2) # 10hz
+
+
+    rpmMsg.commanded_rpms = 100
+    angleMsg.f1_angle_in_radians = 1.
+    angleMsg.f2_angle_in_radians = 1.
+    angleMsg.f3_angle_in_radians = 1.
+    angleMsg.f4_angle_in_radians = 1.
+
+    while not rospy.is_shutdown():
+        simulated_autopilot_angles.publish(angleMsg)
+        simulated_autopilot_RPM.publish(rpmMsg)
+        rate.sleep()

--- a/cmd_actuators_mux/test/jaus_ros_bridge_publisher.py
+++ b/cmd_actuators_mux/test/jaus_ros_bridge_publisher.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import unittest
+import math
+import rosnode
+import rospy
+import rostest
+from fin_control.msg import SetAngles
+from thruster_control.msg import SetRPM
+
+if __name__ == '__main__':
+    rospy.init_node('test_jausRosBridge_publisher')
+    angleMsg = SetAngles()
+    rpmMsg = SetRPM()
+
+    simulated_jausRosBridge_angles = rospy.Publisher(
+        '/input/jausRosBridge/set_angles',
+        SetAngles,
+        queue_size=1)
+    simulated_jausRosBridge_RPM = rospy.Publisher(
+        'input/jaus_ros_bridge/set_rpm',
+        SetRPM,
+        queue_size=1)
+
+    rate = rospy.Rate(2)  # 10hz
+
+    rpmMsg.commanded_rpms = 200
+    angleMsg.f1_angle_in_radians = 2.
+    angleMsg.f2_angle_in_radians = 2.
+    angleMsg.f3_angle_in_radians = 2.
+    angleMsg.f4_angle_in_radians = 2.
+
+    while not rospy.is_shutdown():
+        simulated_jausRosBridge_angles.publish(angleMsg)
+        simulated_jausRosBridge_RPM.publish(rpmMsg)
+        rate.sleep()

--- a/cmd_actuators_mux/test/jaus_ros_bridge_publisher.py
+++ b/cmd_actuators_mux/test/jaus_ros_bridge_publisher.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     rpmMsg = SetRPM()
 
     simulated_jausRosBridge_angles = rospy.Publisher(
-        '/input/jausRosBridge/set_angles',
+        '/input/jaus_ros_bridge/set_angles',
         SetAngles,
         queue_size=1)
     simulated_jausRosBridge_RPM = rospy.Publisher(

--- a/fin_control/CMakeLists.txt
+++ b/fin_control/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(
    FILES
    ReportAngle.msg
-   SetAngle.msg
    SetAngles.msg
 )
 

--- a/fin_control/include/fin_control/fin_control.h
+++ b/fin_control/include/fin_control/fin_control.h
@@ -58,7 +58,6 @@
 #include <diagnostic_tools/health_check.h>
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <fin_control/ReportAngle.h>
-#include <fin_control/SetAngle.h>
 #include <fin_control/SetAngles.h>
 #include <health_monitor/ReportFault.h>
 
@@ -87,7 +86,6 @@ class FinControl
   float degreesToRadians(float degrees);
 
   void reportAngleSendTimeout(const ros::TimerEvent& ev);
-  void handleSetAngle(const fin_control::SetAngle::ConstPtr& msg);
   void handleSetAngles(const fin_control::SetAngles::ConstPtr& msg);
 
   double maxCtrlFinAngle;
@@ -99,7 +97,6 @@ class FinControl
   double maxReportAngleRate;
 
   ros::NodeHandle& nodeHandle;
-  ros::Subscriber subscriber_setAngle;
   ros::Subscriber subscriber_setAngles;
   ros::Subscriber subscriber_enableReportAngles;
   diagnostic_tools::DiagnosedPublisher<

--- a/fin_control/msg/SetAngle.msg
+++ b/fin_control/msg/SetAngle.msg
@@ -1,4 +1,0 @@
-uint16  MAX_ANGLE = 40
-uint8   ID
-float64 angle_in_radians
-

--- a/fin_control/msg/SetAngles.msg
+++ b/fin_control/msg/SetAngles.msg
@@ -1,6 +1,2 @@
 uint16  MAX_ANGLE = 40
-float64 f1_angle_in_radians
-float64 f2_angle_in_radians
-float64 f3_angle_in_radians
-float64 f4_angle_in_radians
-
+float64[4] fin_angle_in_radians

--- a/fin_control/src/fin_control.cpp
+++ b/fin_control/src/fin_control.cpp
@@ -101,8 +101,6 @@ FinControl::FinControl(ros::NodeHandle &nodeHandle)
 
   ROS_INFO("fin control constructor enter");
 
-  subscriber_setAngle =
-      nodeHandle.subscribe("/fin_control/set_angle", 10, &FinControl::handleSetAngle, this);
   subscriber_setAngles =
       nodeHandle.subscribe("/fin_control/set_angles", 10, &FinControl::handleSetAngles, this);
 
@@ -312,30 +310,12 @@ void FinControl::handleSetAngles(const fin_control::SetAngles::ConstPtr &msg)
     }
   }
 }
-  void FinControl::handleSetAngle(const fin_control::SetAngle::ConstPtr &msg)
-  {
-    // check for max angle the fins can mechanically handle
-    if (fabs(msg->angle_in_radians) > maxCtrlFinAngle)
-    {
-      ROS_ERROR("Angle set is out of range: %f rad", msg->angle_in_radians);
-      return;
-    }
 
-    float angle_plus_offet = ctrlFinScaleFactor * (msg->angle_in_radians + ctrlFinOffset);
-
-    // Call dynamixel service
-    boost::mutex::scoped_lock lock(m_mutex);
-
-    const char *log;
-    if (!(myWorkBench.goalPosition(msg->ID, angle_plus_offet, &log)))
-      ROS_ERROR("Could not set servo angle for ID %d %s", msg->ID, log);
-  }
-
-  void FinControl::reportAngleSendTimeout(const ros::TimerEvent &ev)
-  {
-    reportAngles();
-    diagnosticsUpdater.update();
-  }
+void FinControl::reportAngleSendTimeout(const ros::TimerEvent &ev)
+{
+  reportAngles();
+  diagnosticsUpdater.update();
+}
 
 }  // namespace robot
 }  // namespace qna

--- a/fin_control/src/fin_control.cpp
+++ b/fin_control/src/fin_control.cpp
@@ -242,7 +242,7 @@ void FinControl::handleSetAngles(const fin_control::SetAngles::ConstPtr &msg)
   float angle_plus_offset;
 
   // check for max angle the fins can mechanically handle
-  for (uint8_t i = 0; i < 4; i++)
+  for (int i = 0; i < 4; i++)
   {
     if (fabs(msg->fin_angle_in_radians[i]) > maxCtrlFinAngle)
     {

--- a/jaus_ros_bridge/CMakeLists.txt
+++ b/jaus_ros_bridge/CMakeLists.txt
@@ -73,7 +73,6 @@ find_package(catkin REQUIRED COMPONENTS
 ## Generate messages in the 'msg' folder
  add_message_files(
    FILES
-   ActivateManualControl.msg
    EnableLogging.msg
  )
 

--- a/jaus_ros_bridge/include/JausDataManager.h
+++ b/jaus_ros_bridge/include/JausDataManager.h
@@ -112,18 +112,11 @@ class JausDataManager {
 
   ros::NodeHandle& _nodeHandle;
   udpserver* _udp;
-  ros::Publisher _publisher_ActivateManualControl;
   ros::Publisher _publisher_EnableLogging;
   ros::Publisher _publisher_StartMission;
   ros::Publisher _publisher_AbortMission;
   ros::Publisher _publisher_ClearFault;
 
-  bool _activateManualControlEnabled;
-  bool _deactivateFromOCU;
-
-  ros::Timer ActivateManualControl_timer;
-
-  void ActivateManualControlTimeout(const ros::TimerEvent& timer);
   void ResetAll();
 
   // bool _needTimerUpdate;

--- a/jaus_ros_bridge/include/JausDataManager.h
+++ b/jaus_ros_bridge/include/JausDataManager.h
@@ -113,15 +113,10 @@ class JausDataManager {
   ros::NodeHandle& _nodeHandle;
   udpserver* _udp;
   ros::Publisher _publisher_EnableLogging;
-  ros::Publisher _publisher_StartMission;
-  ros::Publisher _publisher_AbortMission;
   ros::Publisher _publisher_ClearFault;
 
   void ResetAll();
 
-  // bool _needTimerUpdate;
-
-  ros::Publisher _publisher_setRPM;
   ros::Subscriber _subscriber_reportRPM;
   int16_t _currentRpm;
 };

--- a/jaus_ros_bridge/include/PowerPlantControl.h
+++ b/jaus_ros_bridge/include/PowerPlantControl.h
@@ -54,7 +54,7 @@ class PowerPlantControl : public JausMessageIn {
  public:
   // PowerPlantControl();
   void init(ros::NodeHandle* nodeHandle);
-
+  void PublishRPM(const bool enable);
   void ProcessData(char* message);
 
   enum PresenceBits { RPMBit = 0, ThrottleBit = 1, GlowPlugStateBit = 2 };
@@ -69,11 +69,14 @@ class PowerPlantControl : public JausMessageIn {
   void StopThruster();
 
  private:
+  void commandRPM(const ros::TimerEvent& ev);
+
   int8_t _powerPlantId;  // 1 byte
   int8_t _powerCmd;      // 1 byte
   int8_t _engineId;      // 1 byte
-  int _rpm;              // 4 bytes - optional
+  int _rpm{0};              // 4 bytes - optional
   ros::Publisher _publisher_setRPM;
+  ros::Timer _commandRPMTimer;
   int _maxRPM;
 
   bool _isSetToZero;

--- a/jaus_ros_bridge/include/ReportFinDeflection.h
+++ b/jaus_ros_bridge/include/ReportFinDeflection.h
@@ -45,7 +45,6 @@
 #define REPORTFINDEFLECTION_H_
 
 #include <fin_control/ReportAngle.h>
-#include <fin_control/SetAngle.h>
 #include "JausMessageOut.h"
 
 // struct FinData{

--- a/jaus_ros_bridge/include/SetFinDeflection.h
+++ b/jaus_ros_bridge/include/SetFinDeflection.h
@@ -47,13 +47,15 @@
 #include <ros/ros.h>
 #include <stdint.h>
 #include "JausMessageIn.h"
+#include <fin_control/SetAngles.h>
 
 class SetFinDeflection : public JausMessageIn {
  private:
   int8_t _finId;              // 1 byte
   int8_t _deflectionAngle;    // 1 byte
   int8_t _deflectionRateCmd;  // 1 byte but not used
-  ros::Publisher _publisher_setAngle;
+  ros::Publisher _publisher_setAngles;
+  std::vector<float> _finAngles;
 
  public:
   void init(ros::NodeHandle* nodeHandle);

--- a/jaus_ros_bridge/include/SetFinDeflection.h
+++ b/jaus_ros_bridge/include/SetFinDeflection.h
@@ -51,14 +51,18 @@
 
 class SetFinDeflection : public JausMessageIn {
  private:
+  void commandFinAngles(const ros::TimerEvent& ev);
+
   int8_t _finId;              // 1 byte
   int8_t _deflectionAngle;    // 1 byte
   int8_t _deflectionRateCmd;  // 1 byte but not used
   ros::Publisher _publisher_setAngles;
-  std::vector<float> _finAngles;
+  ros::Timer _commandFinAnglesTimer;
+  std::vector<float> _finAngles{0.,0.,0.,0.};
 
  public:
   void init(ros::NodeHandle* nodeHandle);
+  void PublishFinAngles(const bool enable);
 
   void ProcessData(char* message);
 

--- a/jaus_ros_bridge/include/SetMissionCommands.h
+++ b/jaus_ros_bridge/include/SetMissionCommands.h
@@ -44,9 +44,11 @@ class SetMissionCommands : public JausMessageIn {
   void init(ros::NodeHandle* nodeHandle);
 
   void ProcessData(char* message, JausCommandID cmdID);
+  void StopMission();
 
  private:
   ros::Publisher _publisher_Execute_mission;
+  ros::Publisher _publisher_Stop_mission;
   ros::Publisher _publisher_Abort_mission;
   ros::Publisher _publisher_Load_mission;
   ros::Publisher _publisher_Query_mission;

--- a/jaus_ros_bridge/msg/ActivateManualControl.msg
+++ b/jaus_ros_bridge/msg/ActivateManualControl.msg
@@ -1,2 +1,0 @@
-bool activate_manual_control
-

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -48,7 +48,6 @@
 #include <std_msgs/UInt16.h>
 #include <std_msgs/UInt8.h>
 
-#include <jaus_ros_bridge/ActivateManualControl.h>
 #include <jaus_ros_bridge/EnableLogging.h>
 #include "JausMessageHeader.h"
 
@@ -82,8 +81,6 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
   _reportMissionInfo.init(nodeHandle, udp);
   _reportMissionInfo.init(nodeHandle, udp);
 
-  _publisher_ActivateManualControl = _nodeHandle.advertise<jaus_ros_bridge::ActivateManualControl>(
-      "/jaus_ros_bridge/activate_manual_control", 1, true);
   _publisher_EnableLogging = _nodeHandle.advertise<jaus_ros_bridge::EnableLogging>(
       "/jaus_ros_bridge/enable_logging", 1, true);
 
@@ -98,12 +95,6 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
       _nodeHandle.advertise<thruster_control::SetRPM>("/thruster_control/set_rpm", 1, true);
 
   _currentRpm = 0;
-  // time out every 2 sec
-  ActivateManualControl_timer = _nodeHandle.createTimer(
-      ros::Duration(2), &JausDataManager::ActivateManualControlTimeout, this);
-  _activateManualControlEnabled = false;
-  _deactivateFromOCU = true;
-  //_needTimerUpdate = false;
 }
 
 JausDataManager::~JausDataManager() {}
@@ -121,22 +112,6 @@ void JausDataManager::ResetAll() {
   _reportMissionInfo.Reset();
 }
 
-void JausDataManager::ActivateManualControlTimeout(const ros::TimerEvent& timer) {
-  if (_activateManualControlEnabled) {
-    _activateManualControlEnabled = false;
-
-  } else {
-    jaus_ros_bridge::ActivateManualControl msg;
-    msg.activate_manual_control = false;
-    _publisher_ActivateManualControl.publish(msg);
-    _activateManualControlEnabled = false;
-    //_needTimerUpdate = false;
-    // Tell thruster to stop if running
-    _thrusterControl.StopThruster();
-    //_udp->TimeoutDisconnect();
-  }
-}
-
 void JausDataManager::SetBatteryPack(string batterypack) {
   _reportBatteryInfo.SetBatteryPack(batterypack);
 }
@@ -152,36 +127,15 @@ void JausDataManager::ProcessReceivedData(char* buffer)
     ResetAll();
   }
   else if (strcmp(buffer, DISCONNECT_COMMAND) == 0) {
-    jaus_ros_bridge::ActivateManualControl msg;
-    msg.activate_manual_control = false;
-    _publisher_ActivateManualControl.publish(msg);
     ROS_INFO(DISCONNECT_COMMAND);
   }
   else if (strcmp(buffer, ACTIVATE_MAUNAL_CONTROL) == 0) {
-    jaus_ros_bridge::ActivateManualControl msg;
-    msg.activate_manual_control = true;
-    _publisher_ActivateManualControl.publish(msg);
-
-    if(!_activateManualControlEnabled&&_deactivateFromOCU){
       ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
-      _deactivateFromOCU = false;
-    }
-    
-    _activateManualControlEnabled = true;
-    //_needTimerUpdate = true;
+
   }
   else if (strcmp(buffer, DEACTIVATE_MAUNAL_CONTROL) == 0) {
-    jaus_ros_bridge::ActivateManualControl msg;
-    msg.activate_manual_control = false;
-    _publisher_ActivateManualControl.publish(msg);
-    if(_activateManualControlEnabled)
       ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);
-    _activateManualControlEnabled = false;
-    _deactivateFromOCU = true;
-    //_needTimerUpdate = false;
-
-    ResetAll();
-  }
+    }
   else if (strcmp(buffer, ENABLE_LOGGING) == 0) {
     jaus_ros_bridge::EnableLogging msg;
     msg.enable_logging = true;

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -91,9 +91,6 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
 
   _subscriber_reportRPM = _nodeHandle.subscribe("/thruster_control/report_rpm", 1,
                                                 &JausDataManager::handleReportRPM, this);
-  _publisher_setRPM =
-      _nodeHandle.advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
-
   _currentRpm = 0;
 }
 
@@ -137,6 +134,7 @@ void JausDataManager::ProcessReceivedData(char* buffer)
   }
   else if (strcmp(buffer, DEACTIVATE_MAUNAL_CONTROL) == 0) {
       ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);
+      //  TODO  (aschapiro) OCU Should send a DEACTIVATE command when mission command is selected
       _finControl.PublishFinAngles(false);
       _thrusterControl.PublishRPM(false);
     }
@@ -168,6 +166,9 @@ void JausDataManager::ProcessReceivedData(char* buffer)
     } else if (commandID == JAUS_COMMAND_ExecuteMission || commandID == JAUS_COMMAND_AbortMission ||
                commandID == JAUS_COMMAND_LoadMission || commandID == JAUS_COMMAND_QueryMissions ||
                commandID == JAUS_COMMAND_RemoveMissions) {
+      //  TODO  (aschapiro) OCU Should send a DEACTIVATE command to shutdown the timers.
+      _finControl.PublishFinAngles(false);
+      _thrusterControl.PublishRPM(false);
       _missionCommands.ProcessData(buffer, commandID);
     } else if (commandID == JAUS_COMMAND_PayloadCMD) {
       _payloadCommands.ProcessData(buffer, commandID);

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -91,6 +91,9 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
 
   _subscriber_reportRPM = _nodeHandle.subscribe("/thruster_control/report_rpm", 1,
                                                 &JausDataManager::handleReportRPM, this);
+  _publisher_setRPM =
+      _nodeHandle.advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
+
   _currentRpm = 0;
 }
 

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -130,10 +130,12 @@ void JausDataManager::ProcessReceivedData(char* buffer)
       _missionCommands.StopMission();
       ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
       _finControl.PublishFinAngles(true);
+      _thrusterControl.PublishRPM(true);
   }
   else if (strcmp(buffer, DEACTIVATE_MAUNAL_CONTROL) == 0) {
       ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);
       _finControl.PublishFinAngles(false);
+      _thrusterControl.PublishRPM(false);
     }
   else if (strcmp(buffer, ENABLE_LOGGING) == 0) {
     jaus_ros_bridge::EnableLogging msg;

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -127,6 +127,7 @@ void JausDataManager::ProcessReceivedData(char* buffer)
     ROS_INFO(DISCONNECT_COMMAND);
   }
   else if (strcmp(buffer, ACTIVATE_MAUNAL_CONTROL) == 0) {
+      _missionCommands.StopMission();
       ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
   }
   else if (strcmp(buffer, DEACTIVATE_MAUNAL_CONTROL) == 0) {

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -91,9 +91,6 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
 
   _subscriber_reportRPM = _nodeHandle.subscribe("/thruster_control/report_rpm", 1,
                                                 &JausDataManager::handleReportRPM, this);
-  _publisher_setRPM =
-      _nodeHandle.advertise<thruster_control::SetRPM>("/thruster_control/set_rpm", 1, true);
-
   _currentRpm = 0;
 }
 
@@ -131,7 +128,6 @@ void JausDataManager::ProcessReceivedData(char* buffer)
   }
   else if (strcmp(buffer, ACTIVATE_MAUNAL_CONTROL) == 0) {
       ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
-
   }
   else if (strcmp(buffer, DEACTIVATE_MAUNAL_CONTROL) == 0) {
       ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -129,9 +129,11 @@ void JausDataManager::ProcessReceivedData(char* buffer)
   else if (strcmp(buffer, ACTIVATE_MAUNAL_CONTROL) == 0) {
       _missionCommands.StopMission();
       ROS_INFO(ACTIVATE_MAUNAL_CONTROL);
+      _finControl.PublishFinAngles(true);
   }
   else if (strcmp(buffer, DEACTIVATE_MAUNAL_CONTROL) == 0) {
       ROS_INFO(DEACTIVATE_MAUNAL_CONTROL);
+      _finControl.PublishFinAngles(false);
     }
   else if (strcmp(buffer, ENABLE_LOGGING) == 0) {
     jaus_ros_bridge::EnableLogging msg;

--- a/jaus_ros_bridge/src/PowerPlantControl.cpp
+++ b/jaus_ros_bridge/src/PowerPlantControl.cpp
@@ -49,7 +49,7 @@
 void PowerPlantControl::init(ros::NodeHandle* nodeHandle) {
   _nodeHandle = nodeHandle;
   _publisher_setRPM =
-      _nodeHandle->advertise<thruster_control::SetRPM>("/input/jausRosBridge/set_rpm", 1, true);
+      _nodeHandle->advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
 
   _isSetToZero = true;
 

--- a/jaus_ros_bridge/src/PowerPlantControl.cpp
+++ b/jaus_ros_bridge/src/PowerPlantControl.cpp
@@ -49,7 +49,7 @@
 void PowerPlantControl::init(ros::NodeHandle* nodeHandle) {
   _nodeHandle = nodeHandle;
   _publisher_setRPM =
-      _nodeHandle->advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
+      _nodeHandle->advertise<thruster_control::SetRPM>("/input/jausRosBridge/set_rpm", 1, true);
 
   _isSetToZero = true;
 

--- a/jaus_ros_bridge/src/PowerPlantControl.cpp
+++ b/jaus_ros_bridge/src/PowerPlantControl.cpp
@@ -49,7 +49,7 @@
 void PowerPlantControl::init(ros::NodeHandle* nodeHandle) {
   _nodeHandle = nodeHandle;
   _publisher_setRPM =
-      _nodeHandle->advertise<thruster_control::SetRPM>("/thruster_control/set_rpm", 1, true);
+      _nodeHandle->advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
 
   _isSetToZero = true;
 

--- a/jaus_ros_bridge/src/SetFinDeflection.cpp
+++ b/jaus_ros_bridge/src/SetFinDeflection.cpp
@@ -67,6 +67,9 @@ void SetFinDeflection::ProcessData(char* message)
   _deflectionAngle = (int8_t)message[index++];  // 1 byte
 
   _finAngles.push_back(JausDataManager::degreesToRadians(_deflectionAngle));
+  // Check that the incoming fin ID is the one we expect it to be
+  ROS_ASSERT_MSG(_finAngles.size() == _finId, "Error incoming ID: %d isn't the expected: %ld",
+                 _finId, _finAngles.size());
 
   // Check that all angles were set
   if (_finAngles.size() == 4)

--- a/jaus_ros_bridge/src/SetFinDeflection.cpp
+++ b/jaus_ros_bridge/src/SetFinDeflection.cpp
@@ -49,7 +49,7 @@ void SetFinDeflection::init(ros::NodeHandle* nodeHandle)
 {
   _nodeHandle = nodeHandle;
   _publisher_setAngles =
-      _nodeHandle->advertise<fin_control::SetAngles>("/fin_control/set_angles", 1, true);
+      _nodeHandle->advertise<fin_control::SetAngles>("input/jausRosBridge/set_angles", 1, true);
 }
 
 void SetFinDeflection::ProcessData(char* message)

--- a/jaus_ros_bridge/src/SetFinDeflection.cpp
+++ b/jaus_ros_bridge/src/SetFinDeflection.cpp
@@ -49,7 +49,7 @@ void SetFinDeflection::init(ros::NodeHandle* nodeHandle)
 {
   _nodeHandle = nodeHandle;
   _publisher_setAngles =
-      _nodeHandle->advertise<fin_control::SetAngles>("input/jausRosBridge/set_angles", 1, true);
+      _nodeHandle->advertise<fin_control::SetAngles>("input/jaus_ros_bridge/set_angles", 1, true);
 
   double finAnglesPublishingRate;
   _nodeHandle->param("fin_angles_publishing_rate", finAnglesPublishingRate, 15.0);
@@ -73,7 +73,7 @@ void SetFinDeflection::ProcessData(char* message)
 
   //  The OCU sends _finID  from 1 to 4
   if(_finId < 5)
-    _finAngles[_finId-1] = _deflectionAngle;
+    _finAngles[_finId-1] = JausDataManager::degreesToRadians(_deflectionAngle);
   else
     ROS_ERROR_STREAM("fin ID out of range - finID: " << _finId);
 

--- a/jaus_ros_bridge/src/SetFinDeflection.cpp
+++ b/jaus_ros_bridge/src/SetFinDeflection.cpp
@@ -72,7 +72,7 @@ void SetFinDeflection::ProcessData(char* message)
   _deflectionAngle = (int8_t)message[index++];  // 1 byte
 
   //  The OCU sends _finID  from 1 to 4
-  if(_finId < 5)
+  if(_finId <= 4)
     _finAngles[_finId-1] = JausDataManager::degreesToRadians(_deflectionAngle);
   else
     ROS_ERROR_STREAM("fin ID out of range - finID: " << _finId);
@@ -96,11 +96,11 @@ int8_t SetFinDeflection::GetDeflectionRateCmd()
 void SetFinDeflection::commandFinAngles(const ros::TimerEvent& ev)
 {
   fin_control::SetAngles msg;
-    for (int i = 0; i < 4; i++)
-    {
-      msg.fin_angle_in_radians[i] = _finAngles[i];
-    }
-    _publisher_setAngles.publish(msg);
+  for (int i = 0; i < 4; i++)
+  {
+    msg.fin_angle_in_radians[i] = _finAngles[i];
+  }
+  _publisher_setAngles.publish(msg);
 }
 
 void SetFinDeflection::PublishFinAngles(const bool enable)

--- a/jaus_ros_bridge/src/SetMissionCommands.cpp
+++ b/jaus_ros_bridge/src/SetMissionCommands.cpp
@@ -42,12 +42,15 @@
 #include <mission_control/LoadMission.h>
 #include <mission_control/QueryMissions.h>
 #include <mission_control/RemoveMissions.h>
+#include "std_msgs/Bool.h"
 
 void SetMissionCommands::init(ros::NodeHandle* nodeHandle) {
   _nodeHandle = nodeHandle;
   // All Set command handlings should be moved to here!
   _publisher_Execute_mission =
       _nodeHandle->advertise<mission_control::ExecuteMission>("/mngr/execute_mission", 1, true);
+  _publisher_Stop_mission =
+      _nodeHandle->advertise<std_msgs::Bool>("/mngr/stop_mission", 1, true);
   _publisher_Abort_mission =
       _nodeHandle->advertise<mission_control::AbortMission>("/mngr/abort_mission", 1, true);
   _publisher_Load_mission =
@@ -108,4 +111,11 @@ void SetMissionCommands::ProcessData(char* message, JausCommandID cmdID) {
       break;
     }
   }
+}
+
+void SetMissionCommands::StopMission()
+{
+  std_msgs::Bool msg;
+  msg.data = true;
+  _publisher_Stop_mission.publish(msg);
 }

--- a/mission_control/include/mission_control/mission_control.h
+++ b/mission_control/include/mission_control/mission_control.h
@@ -59,6 +59,7 @@
 #include "mission_control/ReportHeartbeat.h"
 #include "mission_control/ReportLoadMissionState.h"
 #include "mission_control/ReportMissions.h"
+#include "std_msgs/Bool.h"
 #include "mission_control/mission.h"
 
 #define NODE_VERSION "1.0x"
@@ -82,6 +83,7 @@ private:
 
   void loadMissionCallback(const LoadMission& msg);
   void executeMissionCallback(const ExecuteMission& msg);
+  void stopMissionCallback(const std_msgs::Bool& msg);
   void abortMissionCallback(const AbortMission& msg);
   void queryMissionsCallback(const QueryMissions& msg);
   void removeMissionsCallback(const RemoveMissions& msg);
@@ -95,6 +97,7 @@ private:
 
   ros::Subscriber load_mission_sub_;
   ros::Subscriber execute_mission_sub_;
+  ros::Subscriber stop_mission_sub_;
   ros::Subscriber abort_mission_sub_;
   ros::Subscriber query_mission_sub_;
   ros::Subscriber remove_mission_sub_;

--- a/mission_control/src/mission_control.cpp
+++ b/mission_control/src/mission_control.cpp
@@ -62,6 +62,8 @@ MissionControlNode::MissionControlNode() : nh_(), pnh_("~")
       pnh_.subscribe("load_mission", 1, &MissionControlNode::loadMissionCallback, this);
   execute_mission_sub_ =
       pnh_.subscribe("execute_mission", 1, &MissionControlNode::executeMissionCallback, this);
+  stop_mission_sub_ =
+      pnh_.subscribe("stop_mission", 1, &MissionControlNode::stopMissionCallback, this);
   abort_mission_sub_ =
       pnh_.subscribe("abort_mission", 1, &MissionControlNode::abortMissionCallback, this);
   query_mission_sub_ =
@@ -278,7 +280,14 @@ void MissionControlNode::queryMissionsCallback(const mission_control::QueryMissi
 
   report_missions_pub_.publish(msg);
 }
-
+void MissionControlNode::stopMissionCallback(const std_msgs::Bool& msg)
+{
+  if (current_mission_ && msg.data)
+  {
+    reportOn(current_mission_->preempt());
+    ROS_DEBUG_STREAM("stopMissionsCallback - Stopping mission");
+  }
+}
 void MissionControlNode::removeMissionsCallback(const mission_control::RemoveMissions&)
 {
   ROS_DEBUG_STREAM("removeMissionsCallback - Removing missions");

--- a/mission_control/test/mission_interface.py
+++ b/mission_control/test/mission_interface.py
@@ -45,6 +45,7 @@ from mission_control.msg import ExecuteMission
 from mission_control.msg import ReportExecuteMissionState
 from mission_control.msg import ReportLoadMissionState
 from mission_control.msg import ReportMissions
+from std_msgs.msg import Bool
 
 
 def wait_for(predicate, period=1):
@@ -92,6 +93,12 @@ class MissionInterface:
 
         self.simulated_mission_control_execute_mission_pub = rospy.Publisher(
             '/mission_control_node/execute_mission', ExecuteMission, latch=True, queue_size=1)
+        
+        self.simulated_stop_mission_msg_pub = rospy.Publisher(
+            '/mission_control_node/stop_mission',
+            Bool,
+            latch=True,
+            queue_size=1)
 
     def callback_mission_execute_state(self, msg):
         self.execute_mission_state.append(msg.execute_mission_state)
@@ -120,6 +127,12 @@ class MissionInterface:
         mission_to_execute = ExecuteMission()
         mission_to_execute.mission_id = mission_id
         self.simulated_mission_control_execute_mission_pub.publish(mission_to_execute)
+
+    def stop_mission(self):
+        # Simulate Jaus Ros Bridge sending an Stop Command
+        stop_msgs = Bool()
+        stop_msgs.data = True
+        self.simulated_stop_mission_msg_pub.publish(stop_msgs)
 
     def read_behavior_parameters(self, mission_behavior):
         # Look for the mission behavior in the xml mission file

--- a/mission_control/test/test_jaus_ros_bridge_interface_mission_control.py
+++ b/mission_control/test/test_jaus_ros_bridge_interface_mission_control.py
@@ -119,7 +119,8 @@ class TestJausRosBridgeInterface(unittest.TestCase):
 
     def test_jaus_ros_bridge_interface(self):
         # Test if the mission control reports FAILED if cannot load a mission
-        self.assertEqual(self.mission.load_mission('NO_MISSION'), ReportLoadMissionState.FAILED)
+        self.assertEqual(self.mission.load_mission(
+            'NO_MISSION'), ReportLoadMissionState.FAILED)
 
         # A valid mission is sent to the mission control
         # Execute Mission and check if the mission control reports status
@@ -131,6 +132,24 @@ class TestJausRosBridgeInterface(unittest.TestCase):
             return ReportExecuteMissionState.EXECUTING in self.mission.execute_mission_state
         self.assertTrue(
             wait_for(executing_mission_status_is_reported),
+            msg='Mission control must report EXECUTING')
+
+        # Stop mission
+        self.mission.stop_mission()
+
+        def paused_mission_status_is_reported():
+            return ReportExecuteMissionState.COMPLETE in self.mission.execute_mission_state
+        self.assertTrue(
+            wait_for(paused_mission_status_is_reported),
+            msg='Mission control must report COMPLETE')
+
+        self.mission.execute_mission()
+        # Wait for the mission to report EXECUTING
+
+        def executing_mission_after_stop_status_is_reported():
+            return ReportExecuteMissionState.EXECUTING in self.mission.execute_mission_state
+        self.assertTrue(
+            wait_for(executing_mission_after_stop_status_is_reported),
             msg='Mission control must report EXECUTING')
 
         # Abort mission and wait for it to wrap up

--- a/mission_control/test/test_jaus_ros_bridge_interface_mission_control.py
+++ b/mission_control/test/test_jaus_ros_bridge_interface_mission_control.py
@@ -137,10 +137,10 @@ class TestJausRosBridgeInterface(unittest.TestCase):
         # Stop mission
         self.mission.stop_mission()
 
-        def paused_mission_status_is_reported():
+        def complete_mission_status_is_reported_after_stop_command():
             return ReportExecuteMissionState.COMPLETE in self.mission.execute_mission_state
         self.assertTrue(
-            wait_for(paused_mission_status_is_reported),
+            wait_for(complete_mission_status_is_reported_after_stop_command),
             msg='Mission control must report COMPLETE')
 
         self.mission.execute_mission()


### PR DESCRIPTION
# Description
This PR:
- Removes control flags from Jaus Ros Bridge and Autopilot
- Integrates the [multiplexer](https://github.com/ChrisScianna/ROS-Underwater-RnD/pull/151) for actuator (thruster velocity and fin angles)
- Integrates the change made in [the fin angle msgs](https://github.com/ChrisScianna/ROS-Underwater-RnD/pull/156).
- Because of the multiplexer, Jaus Ros Bridge publishes the thruster velocity and the fin angles continuosly in manual mode.

Discussion of this PR can be found in [Manual vs Autopilot Control Negotiation During Missions](https://github.com/ChrisScianna/ROS-Underwater-RnD/issues/135)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [ ] Linter tests are passing

# Test
The PR was tested on the vehicle:
- Modifying fin_angles and thruster velocity
- Changing to mission control
- Launch mission
- Changing from mission to manual mode
- Aborting Mission