### PR TITLE
Fix LogToBagfile generated bag name suffix

### DIFF
--- a/mission_control/src/behaviors/log_to_bagfile.cpp
+++ b/mission_control/src/behaviors/log_to_bagfile.cpp
@@ -179,8 +179,9 @@ generateBagfilePath(const std::string& prefix)
   {
     const boost::posix_time::ptime now =
       boost::posix_time::second_clock::local_time();
-    boost::posix_time::time_facet facet("%Y-%m-%d-%H-%M-%S");
-    path.imbue(std::locale(path.getloc(), &facet));
+    auto * const facet =
+      new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S");
+    path.imbue(std::locale(path.getloc(), facet));
     path << now << ".bag";
   }
   return path.str();


### PR DESCRIPTION
# Description

Follow-up after #155. This patch fixes a bug in locate facet storage management not previously covered by tests. This has been now corrected.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

Run `mission_control` tests.