### PR TITLE
Make State default in Pose Estimator when GPS didn't fix

### DIFF
--- a/pose_estimator/src/pose_estimator.cpp
+++ b/pose_estimator/src/pose_estimator.cpp
@@ -244,7 +244,12 @@ void PoseEstimator::ahrsCallback(const sensor_msgs::Imu::ConstPtr& ahrs_msg)
     msg.state.geolocation.position.altitude = last_fix_msg_->altitude;
     msg.state.geolocation.covariance = last_fix_msg_->position_covariance;
   }
-
+  else
+  {
+    msg.state.geolocation.position.latitude = std::numeric_limits<double>::quiet_NaN();
+    msg.state.geolocation.position.longitude = std::numeric_limits<double>::quiet_NaN();
+    msg.state.geolocation.position.altitude = std::numeric_limits<double>::quiet_NaN();
+  }
   // Use orientation from AHRS in NED frame
   tf::Quaternion orientation(
       ahrs_msg->orientation.x, ahrs_msg->orientation.y,


### PR DESCRIPTION
# Description
This PR addresses #158 issue.
- The /state default is NaN if GPS has had a fix.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing
