### PR TITLE
Add timer to check connection between OCU and JRB

### DIFF
--- a/jaus_ros_bridge/include/JausDataManager.h
+++ b/jaus_ros_bridge/include/JausDataManager.h
@@ -95,6 +95,8 @@ class JausDataManager {
   void handleReportRPM(const thruster_control::ReportRPM::ConstPtr& msg);
 
  private:
+  void checkOCUConnection(const ros::TimerEvent& ev);
+
   PowerPlantControl _thrusterControl;
   SetFinDeflection _finControl;
   SetMissionCommands _missionCommands;
@@ -114,7 +116,9 @@ class JausDataManager {
   udpserver* _udp;
   ros::Publisher _publisher_EnableLogging;
   ros::Publisher _publisher_ClearFault;
+  ros::Timer _timer_checkOCUCommunication;
 
+  bool _manualControl{false};
   void ResetAll();
 
   ros::Subscriber _subscriber_reportRPM;

--- a/jaus_ros_bridge/include/PowerPlantControl.h
+++ b/jaus_ros_bridge/include/PowerPlantControl.h
@@ -78,6 +78,7 @@ class PowerPlantControl : public JausMessageIn {
   ros::Publisher _publisher_setRPM;
   ros::Timer _commandRPMTimer;
   int _maxRPM;
+  bool _isSetToZero;
 
   ros::Timer ThrusterControl_timer;
 };

--- a/jaus_ros_bridge/include/PowerPlantControl.h
+++ b/jaus_ros_bridge/include/PowerPlantControl.h
@@ -79,7 +79,6 @@ class PowerPlantControl : public JausMessageIn {
   ros::Timer _commandRPMTimer;
   int _maxRPM;
   bool _isSetToZero;
-
   ros::Timer ThrusterControl_timer;
 };
 

--- a/jaus_ros_bridge/include/PowerPlantControl.h
+++ b/jaus_ros_bridge/include/PowerPlantControl.h
@@ -79,7 +79,6 @@ class PowerPlantControl : public JausMessageIn {
   ros::Timer _commandRPMTimer;
   int _maxRPM;
 
-  bool _isSetToZero;
   ros::Timer ThrusterControl_timer;
 };
 

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -93,7 +93,7 @@ JausDataManager::JausDataManager(ros::NodeHandle* nodeHandle, udpserver* udp)
                                                 &JausDataManager::handleReportRPM, this);
 
   double OCUCommunicationTimeOut;
-  _nodeHandle.param("OCU_timeout", OCUCommunicationTimeOut, 5.0);
+  _nodeHandle.param("OCU_timeout", OCUCommunicationTimeOut, 3.0);
   _timer_checkOCUCommunication = _nodeHandle.createTimer(ros::Duration(OCUCommunicationTimeOut),
                                                 &JausDataManager::checkOCUConnection, this);
 

--- a/jaus_ros_bridge/src/JausDataManager.cpp
+++ b/jaus_ros_bridge/src/JausDataManager.cpp
@@ -110,7 +110,7 @@ void JausDataManager::checkOCUConnection(const ros::TimerEvent& ev)
     _thrusterControl.PublishRPM(true);
     _manualControl = false;
   }
-  else 
+  else
   {
     _finControl.PublishFinAngles(false);
     _thrusterControl.PublishRPM(false);

--- a/jaus_ros_bridge/src/PowerPlantControl.cpp
+++ b/jaus_ros_bridge/src/PowerPlantControl.cpp
@@ -51,8 +51,6 @@ void PowerPlantControl::init(ros::NodeHandle* nodeHandle) {
   _publisher_setRPM =
       _nodeHandle->advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
 
-  _isSetToZero = true;
-
   // Info
   // ROS_INFO("Specified max RPM is: +-%d", thruster_control::SetRPM::MAX_RPM);
 
@@ -98,10 +96,6 @@ void PowerPlantControl::ProcessData(char* message) {
       // if(debug_mode)
       ROS_ERROR("RPM exceeded -Max. Set at %d", (0 - thruster_control::SetRPM::MAX_RPM));
     }
-    _isSetToZero = false;
-    if (_rpm == 0) {
-      _isSetToZero = true;
-    }
   }
 }
 
@@ -117,10 +111,7 @@ int PowerPlantControl::GetRpm() {
 }
 
 void PowerPlantControl::StopThruster() {
-  if (_isSetToZero) return;
   _rpm = 0;
-  ROS_INFO("Set thruster rpm to 0 at connection lost!!!");
-  _isSetToZero = true;
 }
 
 void PowerPlantControl::PublishRPM(const bool enable)
@@ -129,6 +120,8 @@ void PowerPlantControl::PublishRPM(const bool enable)
     _commandRPMTimer.start();
   else
     _commandRPMTimer.stop();
+    _rpm = 0;
+
 }
 
 void PowerPlantControl::commandRPM(const ros::TimerEvent& ev)

--- a/jaus_ros_bridge/src/PowerPlantControl.cpp
+++ b/jaus_ros_bridge/src/PowerPlantControl.cpp
@@ -52,6 +52,7 @@ void PowerPlantControl::init(ros::NodeHandle* nodeHandle) {
       _nodeHandle->advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
 
   _isSetToZero = true;
+
   // Info
   // ROS_INFO("Specified max RPM is: +-%d", thruster_control::SetRPM::MAX_RPM);
 

--- a/jaus_ros_bridge/src/PowerPlantControl.cpp
+++ b/jaus_ros_bridge/src/PowerPlantControl.cpp
@@ -51,6 +51,7 @@ void PowerPlantControl::init(ros::NodeHandle* nodeHandle) {
   _publisher_setRPM =
       _nodeHandle->advertise<thruster_control::SetRPM>("input/jaus_ros_bridge/set_rpm", 1, true);
 
+  _isSetToZero = true;
   // Info
   // ROS_INFO("Specified max RPM is: +-%d", thruster_control::SetRPM::MAX_RPM);
 
@@ -96,6 +97,10 @@ void PowerPlantControl::ProcessData(char* message) {
       // if(debug_mode)
       ROS_ERROR("RPM exceeded -Max. Set at %d", (0 - thruster_control::SetRPM::MAX_RPM));
     }
+    _isSetToZero = false;
+    if (_rpm == 0) {
+      _isSetToZero = true;
+    }
   }
 }
 
@@ -111,16 +116,19 @@ int PowerPlantControl::GetRpm() {
 }
 
 void PowerPlantControl::StopThruster() {
+  if (_isSetToZero) return;
   _rpm = 0;
+  _isSetToZero = true;
 }
 
 void PowerPlantControl::PublishRPM(const bool enable)
 {
   if (enable)
     _commandRPMTimer.start();
-  else
+  else{
     _commandRPMTimer.stop();
-    _rpm = 0;
+    StopThruster();
+  }
 
 }
 


### PR DESCRIPTION
# Description
If the Jaus Ros Bridge loses connection with the OCU, The mux will still sending commands to the Mux. Because the Jaus Ros Bridge has more priority than the Autopilot, the vehicle won't receive commands from the mission control / Autopilot.

Taking into accout that the OCU sends "Manual Command" to the Jaus Ros Brids every 1 second, this PR adds a timer in the Jaus Ros Bridge that check the connection with OCU. 
## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings

# How To Test
To check if the timer is working, the connection between the Jaus Ros Bridge and the OCU must be cut manually.