### PR TITLE
Use ROS time in mission_control consistently

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(${PROJECT_NAME} SHARED
   src/behaviors/abort.cpp
   src/behaviors/delay.cpp
   src/behaviors/log_to_bagfile.cpp
+  src/behaviors/timeout.cpp
   src/behaviors/internal/async_bag_writer.cpp
   src/behaviors/internal/generic_subscription.cpp
 )
@@ -117,8 +118,6 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_reactive_action ${PROJECT_NAME} ${catkin_LIBRARIES})
   catkin_add_gtest(test_introspectable_node test/test_introspectable_node.cpp)
   target_link_libraries(test_introspectable_node ${PROJECT_NAME} ${catkin_LIBRARIES})
-  catkin_add_gtest(test_delay_action test/test_delay_action.cpp)
-  target_link_libraries(test_delay_action ${PROJECT_NAME} ${catkin_LIBRARIES})
 
   find_package(rostest REQUIRED)
   add_rostest(test/mission_control_interface.test)
@@ -128,4 +127,12 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/go_to_waypoint_action.test)
   add_rostest(test/set_altitude_heading_action.test)
   add_rostest(test/set_depth_heading_action.test)
+
+  catkin_add_executable_with_gtest(test_delay_action test/test_delay_action.cpp)
+  target_link_libraries(test_delay_action ${PROJECT_NAME} ${catkin_LIBRARIES})
+  add_rostest(test/delay_action.test DEPENDENCIES test_delay_action)
+
+  catkin_add_executable_with_gtest(test_timeout_action test/test_timeout_action.cpp)
+  target_link_libraries(test_timeout_action ${PROJECT_NAME} ${catkin_LIBRARIES})
+  add_rostest(test/timeout_action.test DEPENDENCIES test_timeout_action)
 endif()

--- a/mission_control/include/mission_control/behaviors/delay.h
+++ b/mission_control/include/mission_control/behaviors/delay.h
@@ -35,16 +35,15 @@
 #define MISSION_CONTROL_BEHAVIORS_DELAY_H
 
 #include <behaviortree_cpp_v3/decorator_node.h>
-#include <behaviortree_cpp_v3/decorators/timer_queue.h>
 
 #include <atomic>
 #include <chrono>
 #include <string>
 
+#include "mission_control/behaviors/internal/timer_queue.h"
 
 namespace mission_control
 {
-
 class DelayNode : public BT::DecoratorNode
 {
  public:
@@ -52,10 +51,7 @@ class DelayNode : public BT::DecoratorNode
 
   DelayNode(const std::string& name, const BT::NodeConfiguration& config);
 
-  ~DelayNode() override
-  {
-    halt();
-  }
+  ~DelayNode() override { halt(); }
 
   static BT::PortsList providedPorts()
   {
@@ -69,8 +65,7 @@ class DelayNode : public BT::DecoratorNode
   }
 
  private:
-  BT::TimerQueue timer_;
-  uint64_t timer_id_;
+  internal::TimerQueue timer_;
 
   BT::NodeStatus tick() override;
 
@@ -87,6 +82,6 @@ class DelayNode : public BT::DecoratorNode
   bool read_parameter_from_ports_;
 };
 
-}   // namespace mission_control
+}  // namespace mission_control
 
-#endif   // MISSION_CONTROL_BEHAVIORS_DELAY_H
+#endif  // MISSION_CONTROL_BEHAVIORS_DELAY_H

--- a/mission_control/include/mission_control/behaviors/internal/timer_queue.h
+++ b/mission_control/include/mission_control/behaviors/internal/timer_queue.h
@@ -137,8 +137,8 @@ class TimerQueue
   {
     WorkItem item;
 
-    item.end =
-        ros::Time::now() + ros::Duration().fromNSec(static_cast<int64_t>(milliseconds.count()));
+    auto nanoseconds = static_cast<int64_t>(milliseconds.count() * 1e6);
+    item.end = ros::Time::now() + ros::Duration().fromNSec(nanoseconds);
     item.handler = std::move(handler);
 
     std::unique_lock<std::mutex> lk(m_mtx);

--- a/mission_control/include/mission_control/behaviors/internal/timer_queue.h
+++ b/mission_control/include/mission_control/behaviors/internal/timer_queue.h
@@ -1,0 +1,309 @@
+/*******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021, QinetiQ, Inc.
+ * Copyright (c) 2015 - 2018 Michele Colledanchise
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+#ifndef MISSION_CONTROL_BEHAVIORS_INTERNAL_TIMER_QUEUE_H
+#define MISSION_CONTROL_BEHAVIORS_INTERNAL_TIMER_QUEUE_H
+
+#include <assert.h>
+#include <ros/ros.h>
+#include <rosgraph_msgs/Clock.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace mission_control
+{
+namespace internal
+{
+class Semaphore
+{
+ public:
+  explicit Semaphore(unsigned int count = 0) : m_count(count) {}
+
+  void notify()
+  {
+    std::unique_lock<std::mutex> lock(m_mtx);
+    m_count++;
+    m_cv.notify_one();
+  }
+
+  void wait()
+  {
+    std::unique_lock<std::mutex> lock(m_mtx);
+    m_cv.wait(lock, [this]() { return m_count > 0; });
+    m_count--;
+  }
+
+  bool waitUntil(const ros::Time& time)
+  {
+    std::unique_lock<std::mutex> lock(m_mtx);
+    auto predicate = [this]() { return m_count > 0; };
+    if (ros::Time::isSimTime())
+    {
+      ros::NodeHandle nh;
+      boost::function<void(const rosgraph_msgs::Clock::ConstPtr&)> callback{
+          [this, &time](const rosgraph_msgs::Clock::ConstPtr&) {
+            if (ros::Time::now() >= time) m_cv.notify_one();
+          }};
+      auto sub = nh.subscribe("/clock", 1, callback);
+      while (!predicate())
+      {
+        if (ros::Time::now() >= time)
+        {
+          return false;
+        }
+        m_cv.wait(lock);
+      }
+    }
+    else
+    {
+      const std::chrono::nanoseconds time_since_epoch{
+          static_cast<int64_t>(time.sec * 1e9 + time.nsec)};
+      const std::chrono::system_clock::time_point time_point{time_since_epoch};
+      if (!m_cv.wait_until(lock, time_point, predicate)) return false;
+    }
+    m_count--;
+    return true;
+  }
+
+ private:
+  std::mutex m_mtx;
+  std::condition_variable m_cv;
+  unsigned int m_count;
+};
+
+// Timer Queue
+//
+// Allows execution of handlers at a specified time in the future
+// Guarantees:
+//  - All handlers are executed ONCE, even if canceled (aborted parameter will
+// be set to true)
+//      - If TimerQueue is destroyed, it will cancel all handlers.
+//  - Handlers are ALWAYS executed in the Timer Queue worker thread.
+//  - Handlers execution order is NOT guaranteed
+//
+class TimerQueue
+{
+ public:
+  TimerQueue()
+  {
+    if (!ros::isInitialized())
+    {
+      throw std::runtime_error("TimerQueue needs ROS initialized");
+    }
+    m_th = std::thread([this] { run(); });
+  }
+
+  ~TimerQueue()
+  {
+    cancelAll();
+    // Abusing the timer queue to trigger the shutdown.
+    add(std::chrono::milliseconds(0), [this](bool) { m_finish = true; });  // NOLINT
+    m_th.join();
+  }
+
+  //! Adds a new timer
+  // \return
+  //  Returns the ID of the new timer. You can use this ID to cancel the
+  // timer
+  uint64_t add(std::chrono::milliseconds milliseconds, std::function<void(bool)> handler)
+  {
+    WorkItem item;
+
+    item.end =
+        ros::Time::now() + ros::Duration().fromNSec(static_cast<int64_t>(milliseconds.count()));
+    item.handler = std::move(handler);
+
+    std::unique_lock<std::mutex> lk(m_mtx);
+    uint64_t id = ++m_idcounter;
+    item.id = id;
+    m_items.push(std::move(item));
+    lk.unlock();
+
+    // Something changed, so wake up timer thread
+    m_checkWork.notify();
+    return id;
+  }
+
+  //! Cancels the specified timer
+  // \return
+  //  1 if the timer was cancelled.
+  //  0 if you were too late to cancel (or the timer ID was never valid to
+  // start with)
+  size_t cancel(uint64_t id)
+  {
+    // Instead of removing the item from the container (thus breaking the
+    // heap integrity), we set the item as having no handler, and put
+    // that handler on a new item at the top for immediate execution
+    // The timer thread will then ignore the original item, since it has no
+    // handler.
+    std::unique_lock<std::mutex> lk(m_mtx);
+    for (auto&& item : m_items.getContainer())
+    {
+      if (item.id == id && item.handler)
+      {
+        WorkItem newItem;
+        // Zero time, so it stays at the top for immediate execution
+        newItem.end = ros::Time();
+        newItem.id = 0;  // Means it is a canceled item
+        // Move the handler from item to newitem.
+        // Also, we need to manually set the handler to nullptr, since
+        // the standard does not guarantee moving an std::function will
+        // empty it. Some STL implementation will empty it, others will
+        // not.
+        newItem.handler = std::move(item.handler);
+        item.handler = nullptr;
+        m_items.push(std::move(newItem));
+
+        lk.unlock();
+        // Something changed, so wake up timer thread
+        m_checkWork.notify();
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  //! Cancels all timers
+  // \return
+  //  The number of timers cancelled
+  size_t cancelAll()
+  {
+    // Setting all "end" to 0 (for immediate execution) is ok,
+    // since it maintains the heap integrity
+    std::unique_lock<std::mutex> lk(m_mtx);
+    for (auto&& item : m_items.getContainer())
+    {
+      if (item.id)
+      {
+        item.end = ros::Time();
+        item.id = 0;
+      }
+    }
+    auto ret = m_items.size();
+
+    lk.unlock();
+    m_checkWork.notify();
+    return ret;
+  }
+
+ private:
+  TimerQueue(const TimerQueue&) = delete;
+  TimerQueue& operator=(const TimerQueue&) = delete;
+
+  void run()
+  {
+    while (!m_finish)
+    {
+      auto end = calcWaitTime();
+      if (end.first)
+      {
+        // Timers found, so wait until it expires (or something else
+        // changes)
+        m_checkWork.waitUntil(end.second);
+      }
+      else
+      {
+        // No timers exist, so wait forever until something changes
+        m_checkWork.wait();
+      }
+
+      // Check and execute as much work as possible, such as, all expired
+      // timers
+      checkWork();
+    }
+
+    // If we are shutting down, we should not have any items left,
+    // since the shutdown cancels all items
+    assert(m_items.size() == 0);
+  }
+
+  std::pair<bool, ros::Time> calcWaitTime()
+  {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    while (m_items.size())
+    {
+      if (m_items.top().handler)
+      {
+        // Item present, so return the new wait time
+        return std::make_pair(true, m_items.top().end);
+      }
+      else
+      {
+        // Discard empty handlers (they were cancelled)
+        m_items.pop();
+      }
+    }
+
+    // No items found, so return no wait time (causes the thread to wait
+    // indefinitely)
+    return std::make_pair(false, ros::Time());
+  }
+
+  void checkWork()
+  {
+    std::unique_lock<std::mutex> lk(m_mtx);
+    while (m_items.size() && m_items.top().end <= ros::Time::now())
+    {
+      WorkItem item(std::move(m_items.top()));
+      m_items.pop();
+
+      lk.unlock();
+      if (item.handler) item.handler(item.id == 0);
+      lk.lock();
+    }
+  }
+
+  Semaphore m_checkWork;
+  std::thread m_th;
+  bool m_finish = false;
+  uint64_t m_idcounter = 0;
+
+  struct WorkItem
+  {
+    ros::Time end;
+    uint64_t id;  // id==0 means it was cancelled
+    std::function<void(bool)> handler;
+    bool operator>(const WorkItem& other) const { return end > other.end; }
+  };
+
+  std::mutex m_mtx;
+  // Inheriting from priority_queue, so we can access the internal container
+  class Queue : public std::priority_queue<WorkItem, std::vector<WorkItem>, std::greater<WorkItem>>
+  {
+   public:
+    std::vector<WorkItem>& getContainer() { return this->c; }
+  } m_items;
+};
+
+}  // namespace internal
+}  // namespace mission_control
+
+#endif  // MISSION_CONTROL_BEHAVIORS_INTERNAL_TIMER_QUEUE_H

--- a/mission_control/include/mission_control/behaviors/timeout.h
+++ b/mission_control/include/mission_control/behaviors/timeout.h
@@ -1,0 +1,89 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef MISSION_CONTROL_BEHAVIORS_TIMEOUT_H_
+#define MISSION_CONTROL_BEHAVIORS_TIMEOUT_H_
+
+#include <behaviortree_cpp_v3/decorator_node.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+
+#include "mission_control/behaviors/internal/timer_queue.h"
+
+namespace mission_control
+{
+class TimeoutNode : public BT::DecoratorNode
+{
+ public:
+  TimeoutNode(const std::string& name, std::chrono::milliseconds timeout);
+
+  TimeoutNode(const std::string& name, const BT::NodeConfiguration& config);
+
+  ~TimeoutNode() override { halt(); }
+
+  static BT::PortsList providedPorts()
+  {
+    return {
+        BT::InputPort<unsigned>("msec", "Timeout to halt child if still running, in milliseconds")};
+  }
+
+  void halt() override
+  {
+    timer_.cancelAll();
+    DecoratorNode::halt();
+  }
+
+ private:
+  internal::TimerQueue timer_;
+
+  BT::NodeStatus tick() override;
+
+  std::chrono::milliseconds timeout_;
+
+  enum class Status
+  {
+    PENDING,
+    RUNNING,
+    EXPIRED
+  };
+  std::atomic<Status> timeout_status_;
+
+  bool read_parameter_from_ports_;
+};
+
+}  // namespace mission_control
+
+#endif  // MISSION_CONTROL_BEHAVIORS_TIMEOUT_H_

--- a/mission_control/src/behaviors/delay.cpp
+++ b/mission_control/src/behaviors/delay.cpp
@@ -32,30 +32,28 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "mission_control/behaviors/delay.h"
-
 #include <ros/ros.h>
 
 #include <string>
 
+#include "mission_control/behaviors/delay.h"
 
 namespace mission_control
 {
-
-DelayNode::DelayNode(const std::string& name,  std::chrono::milliseconds delay)
-  : DecoratorNode(name, {}),
-    delay_(delay),
-    delay_status_(Status::PENDING),
-    read_parameter_from_ports_(false)
+DelayNode::DelayNode(const std::string& name, std::chrono::milliseconds delay)
+    : DecoratorNode(name, {}),
+      delay_(delay),
+      delay_status_(Status::PENDING),
+      read_parameter_from_ports_(false)
 {
-    setRegistrationID("Delay");
+  setRegistrationID("Delay");
 }
 
 DelayNode::DelayNode(const std::string& name, const BT::NodeConfiguration& config)
-  : DecoratorNode(name, config),
-    delay_(0u),
-    delay_status_(Status::PENDING),
-    read_parameter_from_ports_(true)
+    : DecoratorNode(name, config),
+      delay_(0u),
+      delay_status_(Status::PENDING),
+      read_parameter_from_ports_(true)
 {
 }
 
@@ -76,19 +74,16 @@ BT::NodeStatus DelayNode::tick()
     }
     delay_status_ = Status::RUNNING;
 
-    timer_id_ = timer_.add(
-      delay_,
-      [this](bool aborted)
+    timer_.add(delay_, [this](bool aborted) {
+      if (!aborted)
       {
-        if (!aborted)
-        {
-          delay_status_ = Status::COMPLETE;
-        }
-        else
-        {
-          delay_status_ = Status::PENDING;
-        }
-      });
+        delay_status_ = Status::COMPLETE;
+      }
+      else
+      {
+        delay_status_ = Status::PENDING;
+      }
+    });
   }
 
   if (Status::COMPLETE != delay_status_)
@@ -104,4 +99,4 @@ BT::NodeStatus DelayNode::tick()
   return child_status;
 }
 
-}   // namespace mission_control
+}  // namespace mission_control

--- a/mission_control/src/behaviors/timeout.cpp
+++ b/mission_control/src/behaviors/timeout.cpp
@@ -46,7 +46,7 @@ TimeoutNode::TimeoutNode(const std::string& name, std::chrono::milliseconds time
       timeout_status_(Status::PENDING),
       read_parameter_from_ports_(false)
 {
-  setRegistrationID("Timeout");
+  setRegistrationID("TimeoutAfter");
 }
 
 TimeoutNode::TimeoutNode(const std::string& name, const BT::NodeConfiguration& config)

--- a/mission_control/src/behaviors/timeout.cpp
+++ b/mission_control/src/behaviors/timeout.cpp
@@ -1,0 +1,105 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, QinetiQ, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of QinetiQ nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <ros/ros.h>
+
+#include <string>
+
+#include "mission_control/behaviors/timeout.h"
+
+namespace mission_control
+{
+TimeoutNode::TimeoutNode(const std::string& name, std::chrono::milliseconds timeout)
+    : DecoratorNode(name, {}),
+      timeout_(timeout),
+      timeout_status_(Status::PENDING),
+      read_parameter_from_ports_(false)
+{
+  setRegistrationID("Timeout");
+}
+
+TimeoutNode::TimeoutNode(const std::string& name, const BT::NodeConfiguration& config)
+    : DecoratorNode(name, config),
+      timeout_(0u),
+      timeout_status_(Status::PENDING),
+      read_parameter_from_ports_(true)
+{
+}
+
+BT::NodeStatus TimeoutNode::tick()
+{
+  if (Status::PENDING == timeout_status_)
+  {
+    if (read_parameter_from_ports_)
+    {
+      unsigned msec_;
+      auto result = getInput("msec", msec_);
+      if (!result)
+      {
+        ROS_ERROR_STREAM("Cannot '" << name() << "': " << result.error());
+        return BT::NodeStatus::FAILURE;
+      }
+      timeout_ = std::chrono::milliseconds(msec_);
+    }
+    timeout_status_ = Status::RUNNING;
+
+    timer_.add(timeout_, [this](bool aborted) {
+      if (!aborted)
+      {
+        timeout_status_ = Status::EXPIRED;
+        haltChild();
+      }
+      else
+      {
+        timeout_status_ = Status::PENDING;
+      }
+    });
+  }
+
+  if (Status::EXPIRED == timeout_status_)
+  {
+    timeout_status_ = Status::PENDING;
+    return BT::NodeStatus::FAILURE;
+  }
+
+  BT::NodeStatus child_status = child()->executeTick();
+  if (BT::NodeStatus::RUNNING != child_status)
+  {
+    timer_.cancelAll();
+    timeout_status_ = Status::PENDING;
+  }
+  return child_status;
+}
+
+}  // namespace mission_control

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -47,6 +47,7 @@
 #include "mission_control/behaviors/payload_command.h"
 #include "mission_control/behaviors/set_altitude_heading.h"
 #include "mission_control/behaviors/set_depth_heading.h"
+#include "mission_control/behaviors/timeout.h"
 
 #include "mission_control/behaviors/introspectable_node.h"
 
@@ -80,6 +81,7 @@ class MissionBehaviorTreeFactory : public BT::BehaviorTreeFactory
     this->registerNodeType<IntrospectableNode<PayloadCommandNode>>("PayloadCommand");
     this->registerNodeType<IntrospectableNode<SetAltitudeHeadingNode>>("SetAltitudeHeading");
     this->registerNodeType<IntrospectableNode<SetDepthHeadingNode>>("SetDepthHeading");
+    this->registerNodeType<IntrospectableNode<TimeoutNode>>("TimeoutAfter");
   }
 };
 

--- a/mission_control/test/delay_action.test
+++ b/mission_control/test/delay_action.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_delay_action" pkg="mission_control" type="test_delay_action" time-limit="10.0" />
+</launch>

--- a/mission_control/test/test_attitude_servo_action.py
+++ b/mission_control/test/test_attitude_servo_action.py
@@ -74,7 +74,7 @@ class TestAttitudeServoAction(unittest.TestCase):
         mission_definition = '''
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
-              <Timeout msec="2000">
+              <TimeoutAfter msec="2000">
                 <AttitudeServo
                     roll="{}"
                     pitch="{}"
@@ -84,7 +84,7 @@ class TestAttitudeServoAction(unittest.TestCase):
                     roll-tolerance="1.0"
                     pitch-tolerance="1.0"
                     yaw-tolerance="1.0"/>
-              </Timeout>
+              </TimeoutAfter>
             </BehaviorTree>
           </root>
         '''.format(roll, math.degrees(pitch), yaw, speed_knots)

--- a/mission_control/test/test_go_to_waypoint_action.py
+++ b/mission_control/test/test_go_to_waypoint_action.py
@@ -65,12 +65,12 @@ class TestGoToWaypointAction(unittest.TestCase):
         mission_definition = '''
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
-              <Timeout msec="2000">
+              <TimeoutAfter msec="2000">
                 <GoToWaypoint
                     latitude="{}" longitude="{}"
                     altitude="{}" speed_knots="{}"
                     tolerance_radius="0.1"/>
-              </Timeout>
+              </TimeoutAfter>
             </BehaviorTree>
           </root>
         '''.format(latitude, longitude, altitude, speed_knots)

--- a/mission_control/test/test_mission_control_failure_modes.py
+++ b/mission_control/test/test_mission_control_failure_modes.py
@@ -91,11 +91,11 @@ class TestMissionControlFailureModes(unittest.TestCase):
         mission_definition = '''
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
-              <Timeout msec="1000">
+              <TimeoutAfter msec="1000">
                 <Delay delay_msec="10000">
                   <AlwaysSuccess/>
                 </Delay>
-              </Timeout>
+              </TimeoutAfter>
             </BehaviorTree>
           </root>
         '''

--- a/mission_control/test/test_set_altitude_heading_action.py
+++ b/mission_control/test/test_set_altitude_heading_action.py
@@ -72,14 +72,14 @@ class TestSetAltitudeHeadingAction(unittest.TestCase):
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
               <Sequence name="Test Mission">
-                <Timeout msec="2000">
+                <TimeoutAfter msec="2000">
                   <SetAltitudeHeading
                       altitude="{}"
                       heading="{}"
                       speed_knots="{}"
                       altitude-tolerance="0.1"
                       heading-tolerance="0.1"/>
-                </Timeout>
+                </TimeoutAfter>
               </Sequence>
             </BehaviorTree>
           </root>

--- a/mission_control/test/test_set_depth_heading_action.py
+++ b/mission_control/test/test_set_depth_heading_action.py
@@ -73,7 +73,7 @@ class TestSetDepthHeadingAction(unittest.TestCase):
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
               <Sequence name="Test Mission">
-                <Timeout msec="2000">
+                <TimeoutAfter msec="2000">
                   <SetDepthHeading
                       depth="{}"
                       heading="{}"
@@ -81,7 +81,7 @@ class TestSetDepthHeadingAction(unittest.TestCase):
                       speed_knots="{}"
                       depth-tolerance="0.1"
                       heading-tolerance="0.1"/>
-                </Timeout>
+                </TimeoutAfter>
               </Sequence>
             </BehaviorTree>
           </root>

--- a/mission_control/test/timeout_action.test
+++ b/mission_control/test/timeout_action.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_timeout_action" pkg="mission_control" type="test_timeout_action" time-limit="10.0" />
+</launch>


### PR DESCRIPTION
# Description

This patch re-implements the upstream `Timeout` decorator and modifies the existing `Delay` decorator to abide to ROS time. To do so, the underlying `TimerQueue` class is also brought in and modified. All this should enable us to run missions in simulations at RTF > 1. It should also go away with all timeout related quirks (such as #143).

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing
- [x] Linter tests are passing

# How To Test

1. Run `mission_control` unit tests:

  ```sh
  catkin_make run_tests_mission_control
  ``` 

2. Test a mission with timeouts and delays in simulation.