### PR TITLE
Rename "Delay" behavior

### DIFF
--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -128,9 +128,9 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/set_altitude_heading_action.test)
   add_rostest(test/set_depth_heading_action.test)
 
-  catkin_add_executable_with_gtest(test_delay_action test/test_delay_action.cpp)
-  target_link_libraries(test_delay_action ${PROJECT_NAME} ${catkin_LIBRARIES})
-  add_rostest(test/delay_action.test DEPENDENCIES test_delay_action)
+  catkin_add_executable_with_gtest(test_delay_for_action test/test_delay_for_action.cpp)
+  target_link_libraries(test_delay_for_action ${PROJECT_NAME} ${catkin_LIBRARIES})
+  add_rostest(test/delay_for_action.test DEPENDENCIES test_delay_for_action)
 
   catkin_add_executable_with_gtest(test_timeout_action test/test_timeout_action.cpp)
   target_link_libraries(test_timeout_action ${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/mission_control/CMakeLists.txt
+++ b/mission_control/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library(${PROJECT_NAME} SHARED
   src/behaviors/set_altitude_heading.cpp
   src/behaviors/payload_command.cpp
   src/behaviors/abort.cpp
-  src/behaviors/delay.cpp
+  src/behaviors/delay_for.cpp
   src/behaviors/log_to_bagfile.cpp
   src/behaviors/timeout.cpp
   src/behaviors/internal/async_bag_writer.cpp

--- a/mission_control/groot_palette/mission_control_behaviors_palette.xml
+++ b/mission_control/groot_palette/mission_control_behaviors_palette.xml
@@ -13,7 +13,7 @@
                 Compression type to be used. Supported types are 'none', 'bz2', and 'lz4'.
             </input_port>
         </Decorator>
-        <Decorator ID="Delay">
+        <Decorator ID="DelayFor">
             <input_port name="delay_msec">Time to delay child ticking, in milliseconds</input_port>
         </Decorator>
         <Action ID="AttitudeServo">
@@ -63,4 +63,3 @@
         </Action>
     </TreeNodesModel>
 </root>
-

--- a/mission_control/src/mission.cpp
+++ b/mission_control/src/mission.cpp
@@ -40,7 +40,7 @@
 
 #include "mission_control/behaviors/abort.h"
 #include "mission_control/behaviors/attitude_servo.h"
-#include "mission_control/behaviors/delay.h"
+#include "mission_control/behaviors/delay_for.h"
 #include "mission_control/behaviors/fix_rudder.h"
 #include "mission_control/behaviors/go_to_waypoint.h"
 #include "mission_control/behaviors/log_to_bagfile.h"
@@ -74,7 +74,7 @@ class MissionBehaviorTreeFactory : public BT::BehaviorTreeFactory
     // TODO(hidmic): load behavior classes from ROS plugins
     this->registerNodeType<IntrospectableNode<AbortNode>>("Abort");
     this->registerNodeType<IntrospectableNode<AttitudeServoNode>>("AttitudeServo");
-    this->registerNodeType<IntrospectableNode<DelayNode>>("Delay");
+    this->registerNodeType<IntrospectableNode<DelayForNode>>("DelayFor");
     this->registerNodeType<IntrospectableNode<FixRudderNode>>("FixRudder");
     this->registerNodeType<IntrospectableNode<GoToWaypointNode>>("GoToWaypoint");
     this->registerNodeType<IntrospectableNode<LogToBagfileNode>>("LogToBagfile");

--- a/mission_control/test/delay_action.test
+++ b/mission_control/test/delay_action.test
@@ -1,3 +1,0 @@
-<launch>
-  <test test-name="test_delay_action" pkg="mission_control" type="test_delay_action" time-limit="10.0" />
-</launch>

--- a/mission_control/test/delay_for_action.test
+++ b/mission_control/test/delay_for_action.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_delay_for_action" pkg="mission_control" type="test_delay_for_action" time-limit="10.0" />
+</launch>

--- a/mission_control/test/test_delay_for_action.cpp
+++ b/mission_control/test/test_delay_for_action.cpp
@@ -39,15 +39,15 @@
 #include <chrono>
 #include <thread>
 
-#include "mission_control/behaviors/delay.h"
+#include "mission_control/behaviors/delay_for.h"
 
 namespace mission_control
 {
 namespace
 {
-TEST(TestDelayNode, nominal)
+TEST(TestDelayForNode, nominal)
 {
-  DelayNode root("delay some time", std::chrono::milliseconds(500));
+  DelayForNode root("delay some time", std::chrono::milliseconds(500));
   BT::AlwaysSuccessNode child("just succeed");
   root.setChild(&child);
 
@@ -72,7 +72,7 @@ TEST(TestDelayNode, nominal)
 
 int main(int argc, char **argv)
 {
-  ros::init(argc, argv, "test_delay_action");
+  ros::init(argc, argv, "test_delay_for_action");
   ros::start();
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/mission_control/test/test_files/test_missions/missionTest.xml
+++ b/mission_control/test/test_files/test_missions/missionTest.xml
@@ -3,9 +3,9 @@
     <BehaviorTree ID="main">
         <Sequence>
           <FixRudder depth="1.0" rudder="2.0" speed_knots="3.0"/>
-          <Delay delay_msec="1000">
+          <DelayFor delay_msec="1000">
             <AlwaysSuccess/>
-          </Delay>
+          </DelayFor>
         </Sequence>
     </BehaviorTree>
   </root>

--- a/mission_control/test/test_files/test_missions/missionTest.xml
+++ b/mission_control/test/test_files/test_missions/missionTest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<root main_tree_to_execute="main">
+    <BehaviorTree ID="main">
+        <Sequence>
+          <FixRudder depth="1.0" rudder="2.0" speed_knots="3.0"/>
+          <Delay delay_msec="1000">
+            <AlwaysSuccess/>
+          </Delay>
+        </Sequence>
+    </BehaviorTree>
+  </root>

--- a/mission_control/test/test_log_to_bagfile_action.py
+++ b/mission_control/test/test_log_to_bagfile_action.py
@@ -62,9 +62,9 @@ class TestLogToBagfileAction(unittest.TestCase):
               <LogToBagfile prefix="{}" topics="{}" compression="{}">
                 <Sequence>
                   <FixRudder depth="1.0" rudder="2.0" speed_knots="3.0"/>
-                  <Delay delay_msec="1000">
+                  <DelayFor delay_msec="1000">
                     <AlwaysSuccess/>
-                  </Delay>
+                  </DelayFor>
                 </Sequence>
               </LogToBagfile>
             </BehaviorTree>
@@ -105,9 +105,9 @@ class TestLogToBagfileAction(unittest.TestCase):
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
               <LogToBagfile prefix="{}">
-                <Delay delay_msec="1000">
+                <DelayFor delay_msec="1000">
                   <AlwaysSuccess/>
-                </Delay>
+                </DelayFor>
               </LogToBagfile>
             </BehaviorTree>
           </root>

--- a/mission_control/test/test_mission_control_failure_modes.py
+++ b/mission_control/test/test_mission_control_failure_modes.py
@@ -92,9 +92,9 @@ class TestMissionControlFailureModes(unittest.TestCase):
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
               <TimeoutAfter msec="1000">
-                <Delay delay_msec="10000">
+                <DelayFor delay_msec="10000">
                   <AlwaysSuccess/>
-                </Delay>
+                </DelayFor>
               </TimeoutAfter>
             </BehaviorTree>
           </root>

--- a/mission_control/test/test_mission_control_interface.py
+++ b/mission_control/test/test_mission_control_interface.py
@@ -88,9 +88,9 @@ class TestMissionControlInterface(unittest.TestCase):
         mission_definition = '''
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
-              <Delay delay_msec="1000">
+              <DelayFor delay_msec="1000">
                 <AlwaysSuccess/>
-              </Delay>
+              </DelayFor>
             </BehaviorTree>
           </root>
         '''
@@ -106,9 +106,9 @@ class TestMissionControlInterface(unittest.TestCase):
         mission_definition = '''
           <root main_tree_to_execute="main">
             <BehaviorTree ID="main">
-              <Delay delay_msec="2000">
+              <DelayFor delay_msec="2000">
                 <AlwaysSuccess/>
-              </Delay>
+              </DelayFor>
             </BehaviorTree>
           </root>
         '''

--- a/mission_control/test/test_timeout_action.cpp
+++ b/mission_control/test/test_timeout_action.cpp
@@ -39,7 +39,7 @@
 #include <chrono>
 #include <thread>
 
-#include "mission_control/behaviors/delay.h"
+#include "mission_control/behaviors/delay_for.h"
 #include "mission_control/behaviors/timeout.h"
 
 namespace mission_control
@@ -49,7 +49,7 @@ namespace
 TEST(TestTimeoutNode, nominal)
 {
   TimeoutNode root("timeout after some time", std::chrono::milliseconds(500));
-  DelayNode decorator("delay for longer", std::chrono::milliseconds(1000));
+  DelayForNode decorator("delay for longer", std::chrono::milliseconds(1000));
   BT::AlwaysSuccessNode child("just succeed");
   decorator.setChild(&child);
   root.setChild(&decorator);


### PR DESCRIPTION
# Description
This PR fixes the issue #176. 
Because BehaviorTree.CPP version on kinetic doesn't have "Delay" action, we had introduced the action as behavior. Now that we are planning to work with Melodic version, we should change the name of the action.

The actions implemented was:
- Rename "Delay" behavior to "DelayFor"
- Modify tests
- Update Groot Palette

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The code builds clean without any errors or warnings
- [x] Unit tests are passing

# How To Test
```sh
catkin_make run_tests_mission_control
```

**Note**: This PR was tested on the machine with melodic version