### PR TITLE
Please roslint in cmd_actuator_mux package

### DIFF
--- a/cmd_actuators_mux/CMakeLists.txt
+++ b/cmd_actuators_mux/CMakeLists.txt
@@ -38,8 +38,8 @@ catkin_package(
 roslint_cpp(
         src/cmd_actuator_mux_nodelet.cpp
         src/cmd_actuator_subscribers.cpp
-        include/cmd_actuators_mux/cmd_actuator_mux_nodelet.cpp
-        include/cmd_actuators_mux/cmd_actuator_subscribers.cpp
+        include/cmd_actuators_mux/cmd_actuator_mux_nodelet.h
+        include/cmd_actuators_mux/cmd_actuator_subscribers.h
         include/cmd_actuators_mux/exceptions.h
 )
 

--- a/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
+++ b/cmd_actuators_mux/src/cmd_actuator_mux_nodelet.cpp
@@ -386,8 +386,8 @@ void CmdActuatorMuxNodelet::reloadConfiguration(cmd_actuators_mux::reloadConfig&
     set_rpm_common_timer.setPeriod(ros::Duration(set_rpm_common_timer_period));
   }
 
-  // check that the both arrays have the same length 
-  ROS_ASSERT_MSG(cmd_set_rpm_subs.size()==(cmd_fin_angles_subs.size()),
+  // check that the both arrays have the same length
+  ROS_ASSERT_MSG(cmd_set_rpm_subs.size()==(cmd_fin_angles_subs.size()),               //NOLINT
                    "Different amount of inputs between SetRPM Subscriber (%d) and "
                    "Fin_Angles Subscribers (%d) in YAML file:",
                    static_cast<int>(cmd_set_rpm_subs.size()),


### PR DESCRIPTION
Precisely what the title says. This patch fixes roslint errors in the cmd_actuator_mux package

## How To Test

```sh
catkin_make run_tests_cmd_actuators_mux_roslint_package
```